### PR TITLE
INTERNAL: Disable Renovate Github Actions `pinDigest`

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -24,6 +24,11 @@
   "automerge": false,
   "branchPrefix": "renovate/",
   "commitMessagePrefix": "chore(renovate): ",
+  "pinDigest": {
+    "github-actions": {
+      "enabled": false
+    }
+  },
 
   "labels": ["dependencies"],
   "postUpdateOptions": ["npmDedupe"]

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -24,12 +24,14 @@
   "automerge": false,
   "branchPrefix": "renovate/",
   "commitMessagePrefix": "chore(renovate): ",
-  "pinDigest": {
-    "github-actions": {
-      "enabled": false
-    }
-  },
 
   "labels": ["dependencies"],
-  "postUpdateOptions": ["npmDedupe"]
+  "postUpdateOptions": ["npmDedupe"],
+
+  "packageRules": [
+    {
+      "matchManagers": ["github-actions"],
+      "pinDigests": false
+    }
+  ]
 }


### PR DESCRIPTION
## Description

Disable Github Actions digest pin in workflow files from Renovate.