### PR TITLE
INTERNAL: Fix get context carrier

### DIFF
--- a/.changeset/proud-taxis-flow.md
+++ b/.changeset/proud-taxis-flow.md
@@ -1,0 +1,5 @@
+---
+"@adobe/aio-lib-telemetry": patch
+---
+
+Fixes a bug where the runtime action `params` weren't being forwarded to the `getContextCarrier` helper of the `instrumentEntrypoint` configuration.

--- a/tests/unit/core/instrumentation.test.ts
+++ b/tests/unit/core/instrumentation.test.ts
@@ -585,6 +585,24 @@ describe("core/instrumentation", () => {
       expect(propagation.deserializeContextFromCarrier).not.toHaveBeenCalled();
     });
 
+    test("should receive params in getContextCarrier", () => {
+      let capturedParams: Record<string, unknown> | null = null;
+      const instrumentedMain = instrumentation.instrumentEntrypoint(mockMain, {
+        initializeTelemetry: mockInitializeTelemetry,
+        propagation: {
+          getContextCarrier: (entrypointParams) => {
+            capturedParams = entrypointParams;
+            return { carrier: {}, baseCtx: undefined };
+          },
+        },
+      });
+
+      const params = { ENABLE_TELEMETRY: "true" };
+      instrumentedMain(params);
+
+      expect(capturedParams).toBe(params);
+    });
+
     test("should use custom base context if provided", () => {
       const baseContext = {} as Context;
 


### PR DESCRIPTION
## Description

This PR fixes a bug where the `getContextCarrier` was not receiving the arguments of the runtime action.