### PR TITLE
INTERNAL: uncomment test `expect` and regenerate api reference

### DIFF
--- a/docs/api-reference/functions/addEventToActiveSpan.md
+++ b/docs/api-reference/functions/addEventToActiveSpan.md
@@ -4,7 +4,7 @@
 function addEventToActiveSpan(event: string, attributes?: Attributes): void;
 ```
 
-Defined in: [api/global.ts:72](https://github.com/adobe/aio-lib-telemetry/blob/dd348342643b2b66d5a8c5267221de639b83642e/source/api/global.ts#L72)
+Defined in: [api/global.ts:72](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/api/global.ts#L72)
 
 Adds an event to the given span.
 

--- a/docs/api-reference/functions/addEventToActiveSpan.md
+++ b/docs/api-reference/functions/addEventToActiveSpan.md
@@ -4,7 +4,7 @@
 function addEventToActiveSpan(event: string, attributes?: Attributes): void;
 ```
 
-Defined in: [api/global.ts:72](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/api/global.ts#L72)
+Defined in: [api/global.ts:72](https://github.com/adobe/aio-lib-telemetry/blob/8f52cfa8868b711535e2b8726ef8da98982edbdf/source/api/global.ts#L72)
 
 Adds an event to the given span.
 

--- a/docs/api-reference/functions/defineMetrics.md
+++ b/docs/api-reference/functions/defineMetrics.md
@@ -4,7 +4,7 @@
 function defineMetrics<T>(createMetrics: (meter: Meter) => T): T;
 ```
 
-Defined in: [core/metrics.ts:52](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/core/metrics.ts#L52)
+Defined in: [core/metrics.ts:52](https://github.com/adobe/aio-lib-telemetry/blob/8f52cfa8868b711535e2b8726ef8da98982edbdf/source/core/metrics.ts#L52)
 
 Helper to define a record of metrics.
 

--- a/docs/api-reference/functions/defineMetrics.md
+++ b/docs/api-reference/functions/defineMetrics.md
@@ -4,15 +4,15 @@
 function defineMetrics<T>(createMetrics: (meter: Meter) => T): T;
 ```
 
-Defined in: [core/config.ts:48](https://github.com/adobe/aio-lib-telemetry/blob/dd348342643b2b66d5a8c5267221de639b83642e/source/core/config.ts#L48)
+Defined in: [core/metrics.ts:52](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/core/metrics.ts#L52)
 
 Helper to define a record of metrics.
 
 ## Type Parameters
 
-| Type Parameter                                    |
-| ------------------------------------------------- |
-| `T` _extends_ `Record`\<`string`, `MetricTypes`\> |
+| Type Parameter                                         |
+| ------------------------------------------------------ |
+| `T` _extends_ `Record`\<`PropertyKey`, `MetricTypes`\> |
 
 ## Parameters
 

--- a/docs/api-reference/functions/defineTelemetryConfig.md
+++ b/docs/api-reference/functions/defineTelemetryConfig.md
@@ -3,33 +3,33 @@
 ```ts
 function defineTelemetryConfig(
   init: (
-    params: RecursiveStringRecord,
+    params: Record<string, unknown>,
     isDevelopment: boolean,
   ) => TelemetryConfig,
 ): {
   initializeTelemetry: (
-    params: RecursiveStringRecord,
+    params: Record<string, unknown>,
     isDevelopment: boolean,
   ) => TelemetryConfig;
 };
 ```
 
-Defined in: [core/config.ts:25](https://github.com/adobe/aio-lib-telemetry/blob/dd348342643b2b66d5a8c5267221de639b83642e/source/core/config.ts#L25)
+Defined in: [core/config.ts:21](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/core/config.ts#L21)
 
 Helper to define the telemetry configuration for an entrypoint.
 
 ## Parameters
 
-| Parameter | Type                                                                                                                     | Description                               |
-| --------- | ------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------- |
-| `init`    | (`params`: `RecursiveStringRecord`, `isDevelopment`: `boolean`) => [`TelemetryConfig`](../interfaces/TelemetryConfig.md) | The function to initialize the telemetry. |
+| Parameter | Type                                                                                                                             | Description                               |
+| --------- | -------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
+| `init`    | (`params`: `Record`\<`string`, `unknown`\>, `isDevelopment`: `boolean`) => [`TelemetryConfig`](../interfaces/TelemetryConfig.md) | The function to initialize the telemetry. |
 
 ## Returns
 
 ```ts
 {
   initializeTelemetry: (
-    params: RecursiveStringRecord,
+    params: Record<string, unknown>,
     isDevelopment: boolean,
   ) => TelemetryConfig;
 }
@@ -38,16 +38,18 @@ Helper to define the telemetry configuration for an entrypoint.
 ### initializeTelemetry()
 
 ```ts
-initializeTelemetry: (params: RecursiveStringRecord, isDevelopment: boolean) =>
-  (TelemetryConfig = init);
+initializeTelemetry: (
+  params: Record<string, unknown>,
+  isDevelopment: boolean,
+) => (TelemetryConfig = init);
 ```
 
 #### Parameters
 
-| Parameter       | Type                    |
-| --------------- | ----------------------- |
-| `params`        | `RecursiveStringRecord` |
-| `isDevelopment` | `boolean`               |
+| Parameter       | Type                            |
+| --------------- | ------------------------------- |
+| `params`        | `Record`\<`string`, `unknown`\> |
+| `isDevelopment` | `boolean`                       |
 
 #### Returns
 

--- a/docs/api-reference/functions/defineTelemetryConfig.md
+++ b/docs/api-reference/functions/defineTelemetryConfig.md
@@ -14,7 +14,7 @@ function defineTelemetryConfig(
 };
 ```
 
-Defined in: [core/config.ts:21](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/core/config.ts#L21)
+Defined in: [core/config.ts:21](https://github.com/adobe/aio-lib-telemetry/blob/8f52cfa8868b711535e2b8726ef8da98982edbdf/source/core/config.ts#L21)
 
 Helper to define the telemetry configuration for an entrypoint.
 

--- a/docs/api-reference/functions/deserializeContextFromCarrier.md
+++ b/docs/api-reference/functions/deserializeContextFromCarrier.md
@@ -7,7 +7,7 @@ function deserializeContextFromCarrier<Carrier>(
 ): Context;
 ```
 
-Defined in: [api/propagation.ts:59](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/api/propagation.ts#L59)
+Defined in: [api/propagation.ts:59](https://github.com/adobe/aio-lib-telemetry/blob/8f52cfa8868b711535e2b8726ef8da98982edbdf/source/api/propagation.ts#L59)
 
 Deserializes the context from a carrier and augments the given base context with it.
 

--- a/docs/api-reference/functions/deserializeContextFromCarrier.md
+++ b/docs/api-reference/functions/deserializeContextFromCarrier.md
@@ -7,15 +7,15 @@ function deserializeContextFromCarrier<Carrier>(
 ): Context;
 ```
 
-Defined in: [api/propagation.ts:59](https://github.com/adobe/aio-lib-telemetry/blob/dd348342643b2b66d5a8c5267221de639b83642e/source/api/propagation.ts#L59)
+Defined in: [api/propagation.ts:59](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/api/propagation.ts#L59)
 
 Deserializes the context from a carrier and augments the given base context with it.
 
 ## Type Parameters
 
-| Type Parameter                                     |
-| -------------------------------------------------- |
-| `Carrier` _extends_ `Record`\<`string`, `string`\> |
+| Type Parameter                                          |
+| ------------------------------------------------------- |
+| `Carrier` _extends_ `Record`\<`PropertyKey`, `string`\> |
 
 ## Parameters
 

--- a/docs/api-reference/functions/getActiveSpan.md
+++ b/docs/api-reference/functions/getActiveSpan.md
@@ -4,7 +4,7 @@
 function getActiveSpan(ctx: Context): Span;
 ```
 
-Defined in: [api/global.ts:30](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/api/global.ts#L30)
+Defined in: [api/global.ts:30](https://github.com/adobe/aio-lib-telemetry/blob/8f52cfa8868b711535e2b8726ef8da98982edbdf/source/api/global.ts#L30)
 
 Gets the active span from the given context.
 

--- a/docs/api-reference/functions/getActiveSpan.md
+++ b/docs/api-reference/functions/getActiveSpan.md
@@ -4,7 +4,7 @@
 function getActiveSpan(ctx: Context): Span;
 ```
 
-Defined in: [api/global.ts:30](https://github.com/adobe/aio-lib-telemetry/blob/dd348342643b2b66d5a8c5267221de639b83642e/source/api/global.ts#L30)
+Defined in: [api/global.ts:30](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/api/global.ts#L30)
 
 Gets the active span from the given context.
 

--- a/docs/api-reference/functions/getAioRuntimeAttributes.md
+++ b/docs/api-reference/functions/getAioRuntimeAttributes.md
@@ -10,7 +10,7 @@ function getAioRuntimeAttributes(): {
 };
 ```
 
-Defined in: [api/attributes.ts:28](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/api/attributes.ts#L28)
+Defined in: [api/attributes.ts:28](https://github.com/adobe/aio-lib-telemetry/blob/8f52cfa8868b711535e2b8726ef8da98982edbdf/source/api/attributes.ts#L28)
 
 Infers some useful attributes for the current action from the Adobe I/O Runtime
 and returns them as a record of key-value pairs.

--- a/docs/api-reference/functions/getAioRuntimeAttributes.md
+++ b/docs/api-reference/functions/getAioRuntimeAttributes.md
@@ -3,19 +3,14 @@
 ```ts
 function getAioRuntimeAttributes(): {
   action.activation_id: string;
-  action.deadline?: string;
+  action.name: string;
   action.namespace: string;
-  action.package_name: string;
-  action.transaction_id: string;
-  deployment.cloud: string;
-  deployment.environment: string;
-  deployment.region: string;
+  environment: string;
   service.name: string;
-  service.version: string;
 };
 ```
 
-Defined in: [api/attributes.ts:28](https://github.com/adobe/aio-lib-telemetry/blob/dd348342643b2b66d5a8c5267221de639b83642e/source/api/attributes.ts#L28)
+Defined in: [api/attributes.ts:28](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/api/attributes.ts#L28)
 
 Infers some useful attributes for the current action from the Adobe I/O Runtime
 and returns them as a record of key-value pairs.
@@ -25,76 +20,41 @@ and returns them as a record of key-value pairs.
 ```ts
 {
   action.activation_id: string;
-  action.deadline?: string;
+  action.name: string;
   action.namespace: string;
-  action.package_name: string;
-  action.transaction_id: string;
-  deployment.cloud: string;
-  deployment.environment: string;
-  deployment.region: string;
+  environment: string;
   service.name: string;
-  service.version: string;
 }
 ```
 
 #### action.activation_id
 
 ```ts
-activation_id: string = meta.activationId;
+action.activation_id: string = meta.activationId;
 ```
 
-#### action.deadline?
+#### action.name
 
 ```ts
-optional deadline: string;
+action.name: string = meta.actionName;
 ```
 
 #### action.namespace
 
 ```ts
-namespace: string = meta.namespace;
+action.namespace: string = meta.namespace;
 ```
 
-#### action.package_name
-
-```ts
-package_name: string = meta.packageName;
-```
-
-#### action.transaction_id
-
-```ts
-transaction_id: string = meta.transactionId;
-```
-
-#### deployment.cloud
-
-```ts
-cloud: string = meta.cloud;
-```
-
-#### deployment.environment
+### environment
 
 ```ts
 environment: string;
 ```
 
-#### deployment.region
-
-```ts
-region: string = meta.region;
-```
-
 #### service.name
 
 ```ts
-name: string = serviceName;
-```
-
-#### service.version
-
-```ts
-version: string = meta.actionVersion;
+service.name: string;
 ```
 
 ## Since

--- a/docs/api-reference/functions/getAioRuntimeResource.md
+++ b/docs/api-reference/functions/getAioRuntimeResource.md
@@ -4,7 +4,7 @@
 function getAioRuntimeResource(): Resource;
 ```
 
-Defined in: [api/attributes.ts:45](https://github.com/adobe/aio-lib-telemetry/blob/dd348342643b2b66d5a8c5267221de639b83642e/source/api/attributes.ts#L45)
+Defined in: [api/attributes.ts:45](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/api/attributes.ts#L45)
 
 Creates a [resource](https://open-telemetry.github.io/opentelemetry-js/interfaces/_opentelemetry_sdk-node.resources.Resource.html)
 from the attributes inferred from the Adobe I/O Runtime and returns it as an OpenTelemetry Resource object.

--- a/docs/api-reference/functions/getAioRuntimeResource.md
+++ b/docs/api-reference/functions/getAioRuntimeResource.md
@@ -4,7 +4,7 @@
 function getAioRuntimeResource(): Resource;
 ```
 
-Defined in: [api/attributes.ts:45](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/api/attributes.ts#L45)
+Defined in: [api/attributes.ts:45](https://github.com/adobe/aio-lib-telemetry/blob/8f52cfa8868b711535e2b8726ef8da98982edbdf/source/api/attributes.ts#L45)
 
 Creates a [resource](https://open-telemetry.github.io/opentelemetry-js/interfaces/_opentelemetry_sdk-node.resources.Resource.html)
 from the attributes inferred from the Adobe I/O Runtime and returns it as an OpenTelemetry Resource object.

--- a/docs/api-reference/functions/getAioRuntimeResourceWithAttributes.md
+++ b/docs/api-reference/functions/getAioRuntimeResourceWithAttributes.md
@@ -6,7 +6,7 @@ function getAioRuntimeResourceWithAttributes(
 ): Resource;
 ```
 
-Defined in: [api/attributes.ts:64](https://github.com/adobe/aio-lib-telemetry/blob/dd348342643b2b66d5a8c5267221de639b83642e/source/api/attributes.ts#L64)
+Defined in: [api/attributes.ts:64](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/api/attributes.ts#L64)
 
 Creates a [resource](https://open-telemetry.github.io/opentelemetry-js/interfaces/_opentelemetry_sdk-node.resources.Resource.html)
 that combines the attributes inferred from the Adobe I/O Runtime with the provided attributes.

--- a/docs/api-reference/functions/getAioRuntimeResourceWithAttributes.md
+++ b/docs/api-reference/functions/getAioRuntimeResourceWithAttributes.md
@@ -6,7 +6,7 @@ function getAioRuntimeResourceWithAttributes(
 ): Resource;
 ```
 
-Defined in: [api/attributes.ts:64](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/api/attributes.ts#L64)
+Defined in: [api/attributes.ts:64](https://github.com/adobe/aio-lib-telemetry/blob/8f52cfa8868b711535e2b8726ef8da98982edbdf/source/api/attributes.ts#L64)
 
 Creates a [resource](https://open-telemetry.github.io/opentelemetry-js/interfaces/_opentelemetry_sdk-node.resources.Resource.html)
 that combines the attributes inferred from the Adobe I/O Runtime with the provided attributes.

--- a/docs/api-reference/functions/getGlobalTelemetryApi.md
+++ b/docs/api-reference/functions/getGlobalTelemetryApi.md
@@ -4,7 +4,7 @@
 function getGlobalTelemetryApi(): TelemetryApi;
 ```
 
-Defined in: [core/telemetry-api.ts:34](https://github.com/adobe/aio-lib-telemetry/blob/dd348342643b2b66d5a8c5267221de639b83642e/source/core/telemetry-api.ts#L34)
+Defined in: [core/telemetry-api.ts:34](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/core/telemetry-api.ts#L34)
 
 Gets the global telemetry API.
 

--- a/docs/api-reference/functions/getGlobalTelemetryApi.md
+++ b/docs/api-reference/functions/getGlobalTelemetryApi.md
@@ -4,7 +4,7 @@
 function getGlobalTelemetryApi(): TelemetryApi;
 ```
 
-Defined in: [core/telemetry-api.ts:34](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/core/telemetry-api.ts#L34)
+Defined in: [core/telemetry-api.ts:34](https://github.com/adobe/aio-lib-telemetry/blob/8f52cfa8868b711535e2b8726ef8da98982edbdf/source/core/telemetry-api.ts#L34)
 
 Gets the global telemetry API.
 

--- a/docs/api-reference/functions/getInstrumentationHelpers.md
+++ b/docs/api-reference/functions/getInstrumentationHelpers.md
@@ -4,7 +4,7 @@
 function getInstrumentationHelpers(): InstrumentationContext;
 ```
 
-Defined in: [core/instrumentation.ts:67](https://github.com/adobe/aio-lib-telemetry/blob/dd348342643b2b66d5a8c5267221de639b83642e/source/core/instrumentation.ts#L67)
+Defined in: [core/instrumentation.ts:71](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/core/instrumentation.ts#L71)
 
 Access helpers for the current instrumented operation.
 

--- a/docs/api-reference/functions/getInstrumentationHelpers.md
+++ b/docs/api-reference/functions/getInstrumentationHelpers.md
@@ -4,7 +4,7 @@
 function getInstrumentationHelpers(): InstrumentationContext;
 ```
 
-Defined in: [core/instrumentation.ts:71](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/core/instrumentation.ts#L71)
+Defined in: [core/instrumentation.ts:71](https://github.com/adobe/aio-lib-telemetry/blob/8f52cfa8868b711535e2b8726ef8da98982edbdf/source/core/instrumentation.ts#L71)
 
 Access helpers for the current instrumented operation.
 

--- a/docs/api-reference/functions/getLogger.md
+++ b/docs/api-reference/functions/getLogger.md
@@ -4,7 +4,7 @@
 function getLogger(name: string, config?: AioLoggerConfig): AioLogger;
 ```
 
-Defined in: [core/logging.ts:78](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/core/logging.ts#L78)
+Defined in: [core/logging.ts:78](https://github.com/adobe/aio-lib-telemetry/blob/8f52cfa8868b711535e2b8726ef8da98982edbdf/source/core/logging.ts#L78)
 
 Gets a logger instance that can export OpenTelemetry logs.
 

--- a/docs/api-reference/functions/getLogger.md
+++ b/docs/api-reference/functions/getLogger.md
@@ -4,7 +4,7 @@
 function getLogger(name: string, config?: AioLoggerConfig): AioLogger;
 ```
 
-Defined in: [core/logging.ts:83](https://github.com/adobe/aio-lib-telemetry/blob/dd348342643b2b66d5a8c5267221de639b83642e/source/core/logging.ts#L83)
+Defined in: [core/logging.ts:78](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/core/logging.ts#L78)
 
 Gets a logger instance that can export OpenTelemetry logs.
 

--- a/docs/api-reference/functions/getPresetInstrumentations.md
+++ b/docs/api-reference/functions/getPresetInstrumentations.md
@@ -6,7 +6,7 @@ function getPresetInstrumentations(
 ): Instrumentation<InstrumentationConfig>[];
 ```
 
-Defined in: [api/presets.ts:53](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/api/presets.ts#L53)
+Defined in: [api/presets.ts:53](https://github.com/adobe/aio-lib-telemetry/blob/8f52cfa8868b711535e2b8726ef8da98982edbdf/source/api/presets.ts#L53)
 
 Gets the instrumentations for a given preset.
 

--- a/docs/api-reference/functions/getPresetInstrumentations.md
+++ b/docs/api-reference/functions/getPresetInstrumentations.md
@@ -3,43 +3,34 @@
 ```ts
 function getPresetInstrumentations(
   preset: TelemetryInstrumentationPreset,
-):
-  | (
-      | HttpInstrumentation
-      | GraphQLInstrumentation
-      | UndiciInstrumentation
-      | WinstonInstrumentation
-    )[]
-  | Instrumentation<InstrumentationConfig>[];
+): Instrumentation<InstrumentationConfig>[];
 ```
 
-Defined in: [api/presets.ts:52](https://github.com/adobe/aio-lib-telemetry/blob/dd348342643b2b66d5a8c5267221de639b83642e/source/api/presets.ts#L52)
+Defined in: [api/presets.ts:53](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/api/presets.ts#L53)
 
 Gets the instrumentations for a given preset.
 
 ## Parameters
 
-| Parameter | Type                                                                                  | Description                                 |
-| --------- | ------------------------------------------------------------------------------------- | ------------------------------------------- |
-| `preset`  | [`TelemetryInstrumentationPreset`](../type-aliases/TelemetryInstrumentationPreset.md) | The preset to get the instrumentations for. |
+| Parameter | Type                                                                                  | Description                                    |
+| --------- | ------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| `preset`  | [`TelemetryInstrumentationPreset`](../type-aliases/TelemetryInstrumentationPreset.md) | The preset to get the instrumentations for. \* |
 
 ## Returns
 
-\| (
-\| `HttpInstrumentation`
-\| `GraphQLInstrumentation`
-\| `UndiciInstrumentation`
-\| `WinstonInstrumentation`)[]
-\| `Instrumentation`\<`InstrumentationConfig`\>[]
+`Instrumentation`\<`InstrumentationConfig`\>[]
 
 The instrumentations for the given preset:
 
 - `full`: All the Node.js [auto-instrumentations](https://www.npmjs.com/package/@opentelemetry/auto-instrumentations-node)
 - `simple`: Instrumentations for:
-  [Http](https://www.npmjs.com/package/@opentelemetry/instrumentation-http),
-  [GraphQL](https://www.npmjs.com/package/@opentelemetry/instrumentation-graphql),
-  [Undici](https://www.npmjs.com/package/@opentelemetry/instrumentation-undici), and
-  [Winston](https://www.npmjs.com/package/@opentelemetry/instrumentation-winston)
+  - [Http](https://www.npmjs.com/package/@opentelemetry/instrumentation-http),
+  - [GraphQL](https://www.npmjs.com/package/@opentelemetry/instrumentation-graphql)
+  - [Undici](https://www.npmjs.com/package/@opentelemetry/instrumentation-undici)
+
+## Throws
+
+If the preset is unknown.
 
 ## Since
 
@@ -49,5 +40,5 @@ The instrumentations for the given preset:
 
 ```ts
 const instrumentations = getPresetInstrumentations("simple");
-// instrumentations = [HttpInstrumentation, GraphQLInstrumentation, UndiciInstrumentation, WinstonInstrumentation]
+// instrumentations = [HttpInstrumentation, GraphQLInstrumentation, UndiciInstrumentation]
 ```

--- a/docs/api-reference/functions/instrument.md
+++ b/docs/api-reference/functions/instrument.md
@@ -7,7 +7,7 @@ function instrument<T>(
 ): (...args: Parameters<T>) => ReturnType<T>;
 ```
 
-Defined in: [core/instrumentation.ts:112](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/core/instrumentation.ts#L112)
+Defined in: [core/instrumentation.ts:112](https://github.com/adobe/aio-lib-telemetry/blob/8f52cfa8868b711535e2b8726ef8da98982edbdf/source/core/instrumentation.ts#L112)
 
 Instruments a function.
 

--- a/docs/api-reference/functions/instrument.md
+++ b/docs/api-reference/functions/instrument.md
@@ -7,7 +7,7 @@ function instrument<T>(
 ): (...args: Parameters<T>) => ReturnType<T>;
 ```
 
-Defined in: [core/instrumentation.ts:108](https://github.com/adobe/aio-lib-telemetry/blob/dd348342643b2b66d5a8c5267221de639b83642e/source/core/instrumentation.ts#L108)
+Defined in: [core/instrumentation.ts:112](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/core/instrumentation.ts#L112)
 
 Instruments a function.
 

--- a/docs/api-reference/functions/instrumentEntrypoint.md
+++ b/docs/api-reference/functions/instrumentEntrypoint.md
@@ -7,7 +7,7 @@ function instrumentEntrypoint<T>(
 ): (params: Record<string, unknown>) => ReturnType<T>;
 ```
 
-Defined in: [core/instrumentation.ts:280](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/core/instrumentation.ts#L280)
+Defined in: [core/instrumentation.ts:280](https://github.com/adobe/aio-lib-telemetry/blob/8f52cfa8868b711535e2b8726ef8da98982edbdf/source/core/instrumentation.ts#L280)
 
 Instruments the entrypoint of a runtime action.
 Needs to be used ONLY with the `main` function of a runtime action.

--- a/docs/api-reference/functions/instrumentEntrypoint.md
+++ b/docs/api-reference/functions/instrumentEntrypoint.md
@@ -3,45 +3,45 @@
 ```ts
 function instrumentEntrypoint<T>(
   fn: T,
-  config: EntrypointInstrumentationConfig<T>,
-): (params: RecursiveStringRecord) => Promise<Awaited<ReturnType<T>>>;
+  config: EntrypointInstrumentationConfig,
+): (params: Record<string, unknown>) => ReturnType<T>;
 ```
 
-Defined in: [core/instrumentation.ts:270](https://github.com/adobe/aio-lib-telemetry/blob/dd348342643b2b66d5a8c5267221de639b83642e/source/core/instrumentation.ts#L270)
+Defined in: [core/instrumentation.ts:280](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/core/instrumentation.ts#L280)
 
 Instruments the entrypoint of a runtime action.
 Needs to be used ONLY with the `main` function of a runtime action.
 
 ## Type Parameters
 
-| Type Parameter                                             |
-| ---------------------------------------------------------- |
-| `T` _extends_ (`params`: `RecursiveStringRecord`) => `any` |
+| Type Parameter                                                     |
+| ------------------------------------------------------------------ |
+| `T` _extends_ (`params`: `Record`\<`string`, `unknown`\>) => `any` |
 
 ## Parameters
 
-| Parameter | Type                                                                                         | Description                                           |
-| --------- | -------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
-| `fn`      | `T`                                                                                          | The entrypoint function to instrument.                |
-| `config`  | [`EntrypointInstrumentationConfig`](../interfaces/EntrypointInstrumentationConfig.md)\<`T`\> | The configuration for the entrypoint instrumentation. |
+| Parameter | Type                                                                                  | Description                                           |
+| --------- | ------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| `fn`      | `T`                                                                                   | The entrypoint function to instrument.                |
+| `config`  | [`EntrypointInstrumentationConfig`](../interfaces/EntrypointInstrumentationConfig.md) | The configuration for the entrypoint instrumentation. |
 
 ## Returns
 
 A wrapped function with the same signature as the original function, but with telemetry instrumentation.
 
 ```ts
-(params: RecursiveStringRecord): Promise<Awaited<ReturnType<T>>>;
+(params: Record<string, unknown>): ReturnType<T>;
 ```
 
 ### Parameters
 
-| Parameter | Type                    |
-| --------- | ----------------------- |
-| `params`  | `RecursiveStringRecord` |
+| Parameter | Type                            |
+| --------- | ------------------------------- |
+| `params`  | `Record`\<`string`, `unknown`\> |
 
 ### Returns
 
-`Promise`\<`Awaited`\<`ReturnType`\<`T`\>\>\>
+`ReturnType`\<`T`\>
 
 ## Throws
 

--- a/docs/api-reference/functions/serializeContextIntoCarrier.md
+++ b/docs/api-reference/functions/serializeContextIntoCarrier.md
@@ -7,7 +7,7 @@ function serializeContextIntoCarrier<Carrier>(
 ): Carrier;
 ```
 
-Defined in: [api/propagation.ts:36](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/api/propagation.ts#L36)
+Defined in: [api/propagation.ts:36](https://github.com/adobe/aio-lib-telemetry/blob/8f52cfa8868b711535e2b8726ef8da98982edbdf/source/api/propagation.ts#L36)
 
 Serializes the current context into a carrier.
 

--- a/docs/api-reference/functions/serializeContextIntoCarrier.md
+++ b/docs/api-reference/functions/serializeContextIntoCarrier.md
@@ -7,15 +7,15 @@ function serializeContextIntoCarrier<Carrier>(
 ): Carrier;
 ```
 
-Defined in: [api/propagation.ts:36](https://github.com/adobe/aio-lib-telemetry/blob/dd348342643b2b66d5a8c5267221de639b83642e/source/api/propagation.ts#L36)
+Defined in: [api/propagation.ts:36](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/api/propagation.ts#L36)
 
 Serializes the current context into a carrier.
 
 ## Type Parameters
 
-| Type Parameter                                     |
-| -------------------------------------------------- |
-| `Carrier` _extends_ `Record`\<`string`, `string`\> |
+| Type Parameter                                          |
+| ------------------------------------------------------- |
+| `Carrier` _extends_ `Record`\<`PropertyKey`, `string`\> |
 
 ## Parameters
 

--- a/docs/api-reference/functions/tryAddEventToActiveSpan.md
+++ b/docs/api-reference/functions/tryAddEventToActiveSpan.md
@@ -7,7 +7,7 @@ function tryAddEventToActiveSpan(
 ): boolean;
 ```
 
-Defined in: [api/global.ts:88](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/api/global.ts#L88)
+Defined in: [api/global.ts:88](https://github.com/adobe/aio-lib-telemetry/blob/8f52cfa8868b711535e2b8726ef8da98982edbdf/source/api/global.ts#L88)
 
 Tries to add an event to the active span.
 

--- a/docs/api-reference/functions/tryAddEventToActiveSpan.md
+++ b/docs/api-reference/functions/tryAddEventToActiveSpan.md
@@ -7,7 +7,7 @@ function tryAddEventToActiveSpan(
 ): boolean;
 ```
 
-Defined in: [api/global.ts:88](https://github.com/adobe/aio-lib-telemetry/blob/dd348342643b2b66d5a8c5267221de639b83642e/source/api/global.ts#L88)
+Defined in: [api/global.ts:88](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/api/global.ts#L88)
 
 Tries to add an event to the active span.
 

--- a/docs/api-reference/functions/tryGetActiveSpan.md
+++ b/docs/api-reference/functions/tryGetActiveSpan.md
@@ -4,7 +4,7 @@
 function tryGetActiveSpan(ctx: Context): null | Span;
 ```
 
-Defined in: [api/global.ts:52](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/api/global.ts#L52)
+Defined in: [api/global.ts:52](https://github.com/adobe/aio-lib-telemetry/blob/8f52cfa8868b711535e2b8726ef8da98982edbdf/source/api/global.ts#L52)
 
 Tries to get the active span from the given context.
 

--- a/docs/api-reference/functions/tryGetActiveSpan.md
+++ b/docs/api-reference/functions/tryGetActiveSpan.md
@@ -4,7 +4,7 @@
 function tryGetActiveSpan(ctx: Context): null | Span;
 ```
 
-Defined in: [api/global.ts:52](https://github.com/adobe/aio-lib-telemetry/blob/dd348342643b2b66d5a8c5267221de639b83642e/source/api/global.ts#L52)
+Defined in: [api/global.ts:52](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/api/global.ts#L52)
 
 Tries to get the active span from the given context.
 

--- a/docs/api-reference/interfaces/EntrypointInstrumentationConfig.md
+++ b/docs/api-reference/interfaces/EntrypointInstrumentationConfig.md
@@ -1,6 +1,6 @@
-# `EntrypointInstrumentationConfig\<T\>`
+# `EntrypointInstrumentationConfig`
 
-Defined in: [types.ts:163](https://github.com/adobe/aio-lib-telemetry/blob/dd348342643b2b66d5a8c5267221de639b83642e/source/types.ts#L163)
+Defined in: [types.ts:187](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L187)
 
 The configuration for entrypoint instrumentation.
 
@@ -10,13 +10,7 @@ The configuration for entrypoint instrumentation.
 
 ## Extends
 
-- [`InstrumentationConfig`](InstrumentationConfig.md)\<`T`\>
-
-## Type Parameters
-
-| Type Parameter              | Default type  |
-| --------------------------- | ------------- |
-| `T` _extends_ `AnyFunction` | `AnyFunction` |
+- [`InstrumentationConfig`](InstrumentationConfig.md)\<(`params`: `Record`\<`string`, `unknown`\>) => `unknown`\>
 
 ## Properties
 
@@ -25,11 +19,11 @@ The configuration for entrypoint instrumentation.
 ```ts
 optional hooks: {
   onError?: (error: unknown, span: Span) => undefined | Error;
-  onResult?: (result: ReturnType<T>, span: Span) => void;
+  onResult?: (result: unknown, span: Span) => void;
 };
 ```
 
-Defined in: [types.ts:123](https://github.com/adobe/aio-lib-telemetry/blob/dd348342643b2b66d5a8c5267221de639b83642e/source/types.ts#L123)
+Defined in: [types.ts:138](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L138)
 
 Hooks that can be used to act on a span depending on the result of the function.
 
@@ -53,10 +47,14 @@ You can use it to do something with the Span.
 
 `undefined` \| `Error`
 
+##### Since
+
+0.1.0
+
 #### onResult()?
 
 ```ts
-optional onResult: (result: ReturnType<T>, span: Span) => void;
+optional onResult: (result: unknown, span: Span) => void;
 ```
 
 A function that will be called with the result of the instrumented function (if any, and no error was thrown).
@@ -64,14 +62,18 @@ You can use it to do something with the Span.
 
 ##### Parameters
 
-| Parameter | Type                | Description                              |
-| --------- | ------------------- | ---------------------------------------- |
-| `result`  | `ReturnType`\<`T`\> | The result of the instrumented function. |
-| `span`    | `Span`              | The span of the instrumented function.   |
+| Parameter | Type      | Description                              |
+| --------- | --------- | ---------------------------------------- |
+| `result`  | `unknown` | The result of the instrumented function. |
+| `span`    | `Span`    | The span of the instrumented function.   |
 
 ##### Returns
 
 `void`
+
+##### Since
+
+0.1.0
 
 #### Inherited from
 
@@ -82,20 +84,22 @@ You can use it to do something with the Span.
 ### initializeTelemetry()
 
 ```ts
-initializeTelemetry: (params: RecursiveStringRecord, isDevelopment: boolean) =>
-  TelemetryConfig;
+initializeTelemetry: (
+  params: Record<string, unknown>,
+  isDevelopment: boolean,
+) => TelemetryConfig;
 ```
 
-Defined in: [types.ts:179](https://github.com/adobe/aio-lib-telemetry/blob/dd348342643b2b66d5a8c5267221de639b83642e/source/types.ts#L179)
+Defined in: [types.ts:206](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L206)
 
 This function is called at the start of the action.
 
 #### Parameters
 
-| Parameter       | Type                    | Description                                        |
-| --------------- | ----------------------- | -------------------------------------------------- |
-| `params`        | `RecursiveStringRecord` | The parameters of the action.                      |
-| `isDevelopment` | `boolean`               | Whether the action is running in development mode. |
+| Parameter       | Type                            | Description                                        |
+| --------------- | ------------------------------- | -------------------------------------------------- |
+| `params`        | `Record`\<`string`, `unknown`\> | The parameters of the action.                      |
+| `isDevelopment` | `boolean`                       | Whether the action is running in development mode. |
 
 #### Returns
 
@@ -103,30 +107,38 @@ This function is called at the start of the action.
 
 The telemetry configuration to use for the action.
 
+#### Since
+
+0.1.0
+
 ---
 
 ### isSuccessful()?
 
 ```ts
-optional isSuccessful: (result: ReturnType<T>) => boolean;
+optional isSuccessful: (result: unknown) => boolean;
 ```
 
-Defined in: [types.ts:120](https://github.com/adobe/aio-lib-telemetry/blob/dd348342643b2b66d5a8c5267221de639b83642e/source/types.ts#L120)
+Defined in: [types.ts:135](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L135)
 
 A function that will be called to determine if the instrumented function was successful.
 By default, the function is considered successful if it doesn't throw an error.
 
 #### Parameters
 
-| Parameter | Type                | Description                              |
-| --------- | ------------------- | ---------------------------------------- |
-| `result`  | `ReturnType`\<`T`\> | The result of the instrumented function. |
+| Parameter | Type      | Description                              |
+| --------- | --------- | ---------------------------------------- |
+| `result`  | `unknown` | The result of the instrumented function. |
 
 #### Returns
 
 `boolean`
 
 Whether the instrumented function was successful.
+
+#### Since
+
+0.1.0
 
 #### Inherited from
 
@@ -137,13 +149,17 @@ Whether the instrumented function was successful.
 ### propagation?
 
 ```ts
-optional propagation: TelemetryPropagationConfig<T>;
+optional propagation: TelemetryPropagationConfig;
 ```
 
-Defined in: [types.ts:170](https://github.com/adobe/aio-lib-telemetry/blob/dd348342643b2b66d5a8c5267221de639b83642e/source/types.ts#L170)
+Defined in: [types.ts:195](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L195)
 
 Configuration options related to context propagation.
 See the [TelemetryPropagationConfig](TelemetryPropagationConfig.md) for the interface.
+
+#### Since
+
+0.1.0
 
 ---
 
@@ -151,12 +167,12 @@ See the [TelemetryPropagationConfig](TelemetryPropagationConfig.md) for the inte
 
 ```ts
 optional spanConfig: SpanOptions & {
-  getBaseContext?: (...args: Parameters<T>) => Context;
+  getBaseContext?: (...args: [Record<string, unknown>]) => Context;
   spanName?: string;
 };
 ```
 
-Defined in: [types.ts:97](https://github.com/adobe/aio-lib-telemetry/blob/dd348342643b2b66d5a8c5267221de639b83642e/source/types.ts#L97)
+Defined in: [types.ts:106](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L106)
 
 Configuration options related to the span started by the instrumented function.
 See also the [SpanOptions](https://open-telemetry.github.io/opentelemetry-js/interfaces/_opentelemetry_api._opentelemetry_api.SpanOptions.html) interface.
@@ -166,22 +182,26 @@ See also the [SpanOptions](https://open-telemetry.github.io/opentelemetry-js/int
 ##### getBaseContext()?
 
 ```ts
-optional getBaseContext: (...args: Parameters<T>) => Context;
+optional getBaseContext: (...args: [Record<string, unknown>]) => Context;
 ```
 
 The base context to use for the started span.
 
 ###### Parameters
 
-| Parameter | Type                | Description                                 |
-| --------- | ------------------- | ------------------------------------------- |
-| ...`args` | `Parameters`\<`T`\> | The arguments of the instrumented function. |
+| Parameter | Type                                | Description                                 |
+| --------- | ----------------------------------- | ------------------------------------------- |
+| ...`args` | \[`Record`\<`string`, `unknown`\>\] | The arguments of the instrumented function. |
 
 ###### Returns
 
 `Context`
 
 The base context to use for the started span.
+
+###### Since
+
+0.1.0
 
 ##### spanName?
 
@@ -191,6 +211,14 @@ optional spanName: string;
 
 The name of the span. Defaults to the name of given function.
 You must use a named function or a provide a name here.
+
+###### Since
+
+0.1.0
+
+#### Since
+
+0.1.0
 
 #### Inherited from
 

--- a/docs/api-reference/interfaces/EntrypointInstrumentationConfig.md
+++ b/docs/api-reference/interfaces/EntrypointInstrumentationConfig.md
@@ -1,6 +1,6 @@
 # `EntrypointInstrumentationConfig`
 
-Defined in: [types.ts:187](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L187)
+Defined in: [types.ts:187](https://github.com/adobe/aio-lib-telemetry/blob/8f52cfa8868b711535e2b8726ef8da98982edbdf/source/types.ts#L187)
 
 The configuration for entrypoint instrumentation.
 
@@ -23,7 +23,7 @@ optional hooks: {
 };
 ```
 
-Defined in: [types.ts:138](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L138)
+Defined in: [types.ts:138](https://github.com/adobe/aio-lib-telemetry/blob/8f52cfa8868b711535e2b8726ef8da98982edbdf/source/types.ts#L138)
 
 Hooks that can be used to act on a span depending on the result of the function.
 
@@ -90,7 +90,7 @@ initializeTelemetry: (
 ) => TelemetryConfig;
 ```
 
-Defined in: [types.ts:206](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L206)
+Defined in: [types.ts:206](https://github.com/adobe/aio-lib-telemetry/blob/8f52cfa8868b711535e2b8726ef8da98982edbdf/source/types.ts#L206)
 
 This function is called at the start of the action.
 
@@ -119,7 +119,7 @@ The telemetry configuration to use for the action.
 optional isSuccessful: (result: unknown) => boolean;
 ```
 
-Defined in: [types.ts:135](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L135)
+Defined in: [types.ts:135](https://github.com/adobe/aio-lib-telemetry/blob/8f52cfa8868b711535e2b8726ef8da98982edbdf/source/types.ts#L135)
 
 A function that will be called to determine if the instrumented function was successful.
 By default, the function is considered successful if it doesn't throw an error.
@@ -152,7 +152,7 @@ Whether the instrumented function was successful.
 optional propagation: TelemetryPropagationConfig;
 ```
 
-Defined in: [types.ts:195](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L195)
+Defined in: [types.ts:195](https://github.com/adobe/aio-lib-telemetry/blob/8f52cfa8868b711535e2b8726ef8da98982edbdf/source/types.ts#L195)
 
 Configuration options related to context propagation.
 See the [TelemetryPropagationConfig](TelemetryPropagationConfig.md) for the interface.
@@ -172,7 +172,7 @@ optional spanConfig: SpanOptions & {
 };
 ```
 
-Defined in: [types.ts:106](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L106)
+Defined in: [types.ts:106](https://github.com/adobe/aio-lib-telemetry/blob/8f52cfa8868b711535e2b8726ef8da98982edbdf/source/types.ts#L106)
 
 Configuration options related to the span started by the instrumented function.
 See also the [SpanOptions](https://open-telemetry.github.io/opentelemetry-js/interfaces/_opentelemetry_api._opentelemetry_api.SpanOptions.html) interface.

--- a/docs/api-reference/interfaces/InstrumentationConfig.md
+++ b/docs/api-reference/interfaces/InstrumentationConfig.md
@@ -1,6 +1,6 @@
 # `InstrumentationConfig\<T\>`
 
-Defined in: [types.ts:92](https://github.com/adobe/aio-lib-telemetry/blob/dd348342643b2b66d5a8c5267221de639b83642e/source/types.ts#L92)
+Defined in: [types.ts:99](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L99)
 
 The configuration for instrumentation.
 
@@ -29,7 +29,7 @@ optional hooks: {
 };
 ```
 
-Defined in: [types.ts:123](https://github.com/adobe/aio-lib-telemetry/blob/dd348342643b2b66d5a8c5267221de639b83642e/source/types.ts#L123)
+Defined in: [types.ts:138](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L138)
 
 Hooks that can be used to act on a span depending on the result of the function.
 
@@ -53,6 +53,10 @@ You can use it to do something with the Span.
 
 `undefined` \| `Error`
 
+##### Since
+
+0.1.0
+
 #### onResult()?
 
 ```ts
@@ -73,6 +77,10 @@ You can use it to do something with the Span.
 
 `void`
 
+##### Since
+
+0.1.0
+
 ---
 
 ### isSuccessful()?
@@ -81,7 +89,7 @@ You can use it to do something with the Span.
 optional isSuccessful: (result: ReturnType<T>) => boolean;
 ```
 
-Defined in: [types.ts:120](https://github.com/adobe/aio-lib-telemetry/blob/dd348342643b2b66d5a8c5267221de639b83642e/source/types.ts#L120)
+Defined in: [types.ts:135](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L135)
 
 A function that will be called to determine if the instrumented function was successful.
 By default, the function is considered successful if it doesn't throw an error.
@@ -98,6 +106,10 @@ By default, the function is considered successful if it doesn't throw an error.
 
 Whether the instrumented function was successful.
 
+#### Since
+
+0.1.0
+
 ---
 
 ### spanConfig?
@@ -109,7 +121,7 @@ optional spanConfig: SpanOptions & {
 };
 ```
 
-Defined in: [types.ts:97](https://github.com/adobe/aio-lib-telemetry/blob/dd348342643b2b66d5a8c5267221de639b83642e/source/types.ts#L97)
+Defined in: [types.ts:106](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L106)
 
 Configuration options related to the span started by the instrumented function.
 See also the [SpanOptions](https://open-telemetry.github.io/opentelemetry-js/interfaces/_opentelemetry_api._opentelemetry_api.SpanOptions.html) interface.
@@ -136,6 +148,10 @@ The base context to use for the started span.
 
 The base context to use for the started span.
 
+###### Since
+
+0.1.0
+
 ##### spanName?
 
 ```ts
@@ -144,3 +160,11 @@ optional spanName: string;
 
 The name of the span. Defaults to the name of given function.
 You must use a named function or a provide a name here.
+
+###### Since
+
+0.1.0
+
+#### Since
+
+0.1.0

--- a/docs/api-reference/interfaces/InstrumentationConfig.md
+++ b/docs/api-reference/interfaces/InstrumentationConfig.md
@@ -1,6 +1,6 @@
 # `InstrumentationConfig\<T\>`
 
-Defined in: [types.ts:99](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L99)
+Defined in: [types.ts:99](https://github.com/adobe/aio-lib-telemetry/blob/8f52cfa8868b711535e2b8726ef8da98982edbdf/source/types.ts#L99)
 
 The configuration for instrumentation.
 
@@ -29,7 +29,7 @@ optional hooks: {
 };
 ```
 
-Defined in: [types.ts:138](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L138)
+Defined in: [types.ts:138](https://github.com/adobe/aio-lib-telemetry/blob/8f52cfa8868b711535e2b8726ef8da98982edbdf/source/types.ts#L138)
 
 Hooks that can be used to act on a span depending on the result of the function.
 
@@ -89,7 +89,7 @@ You can use it to do something with the Span.
 optional isSuccessful: (result: ReturnType<T>) => boolean;
 ```
 
-Defined in: [types.ts:135](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L135)
+Defined in: [types.ts:135](https://github.com/adobe/aio-lib-telemetry/blob/8f52cfa8868b711535e2b8726ef8da98982edbdf/source/types.ts#L135)
 
 A function that will be called to determine if the instrumented function was successful.
 By default, the function is considered successful if it doesn't throw an error.
@@ -121,7 +121,7 @@ optional spanConfig: SpanOptions & {
 };
 ```
 
-Defined in: [types.ts:106](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L106)
+Defined in: [types.ts:106](https://github.com/adobe/aio-lib-telemetry/blob/8f52cfa8868b711535e2b8726ef8da98982edbdf/source/types.ts#L106)
 
 Configuration options related to the span started by the instrumented function.
 See also the [SpanOptions](https://open-telemetry.github.io/opentelemetry-js/interfaces/_opentelemetry_api._opentelemetry_api.SpanOptions.html) interface.

--- a/docs/api-reference/interfaces/InstrumentationContext.md
+++ b/docs/api-reference/interfaces/InstrumentationContext.md
@@ -1,6 +1,6 @@
 # `InstrumentationContext`
 
-Defined in: [types.ts:234](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L234)
+Defined in: [types.ts:234](https://github.com/adobe/aio-lib-telemetry/blob/8f52cfa8868b711535e2b8726ef8da98982edbdf/source/types.ts#L234)
 
 The context for the current operation.
 
@@ -16,7 +16,7 @@ The context for the current operation.
 contextCarrier: Record<PropertyKey, string>;
 ```
 
-Defined in: [types.ts:263](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L263)
+Defined in: [types.ts:263](https://github.com/adobe/aio-lib-telemetry/blob/8f52cfa8868b711535e2b8726ef8da98982edbdf/source/types.ts#L263)
 
 Holds a carrier that can be used to propagate the active context.
 
@@ -32,7 +32,7 @@ Holds a carrier that can be used to propagate the active context.
 currentSpan: Span;
 ```
 
-Defined in: [types.ts:257](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L257)
+Defined in: [types.ts:257](https://github.com/adobe/aio-lib-telemetry/blob/8f52cfa8868b711535e2b8726ef8da98982edbdf/source/types.ts#L257)
 
 The span of the current operation.
 
@@ -48,7 +48,7 @@ The span of the current operation.
 logger: AioLogger;
 ```
 
-Defined in: [types.ts:251](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L251)
+Defined in: [types.ts:251](https://github.com/adobe/aio-lib-telemetry/blob/8f52cfa8868b711535e2b8726ef8da98982edbdf/source/types.ts#L251)
 
 The logger for the current operation.
 
@@ -64,7 +64,7 @@ The logger for the current operation.
 meter: Meter;
 ```
 
-Defined in: [types.ts:245](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L245)
+Defined in: [types.ts:245](https://github.com/adobe/aio-lib-telemetry/blob/8f52cfa8868b711535e2b8726ef8da98982edbdf/source/types.ts#L245)
 
 The global (managed by the library) meter instance used to create metrics.
 
@@ -80,7 +80,7 @@ The global (managed by the library) meter instance used to create metrics.
 tracer: Tracer;
 ```
 
-Defined in: [types.ts:239](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L239)
+Defined in: [types.ts:239](https://github.com/adobe/aio-lib-telemetry/blob/8f52cfa8868b711535e2b8726ef8da98982edbdf/source/types.ts#L239)
 
 The global (managed by the library) tracer instance used to create spans.
 

--- a/docs/api-reference/interfaces/InstrumentationContext.md
+++ b/docs/api-reference/interfaces/InstrumentationContext.md
@@ -1,6 +1,6 @@
 # `InstrumentationContext`
 
-Defined in: [types.ts:201](https://github.com/adobe/aio-lib-telemetry/blob/dd348342643b2b66d5a8c5267221de639b83642e/source/types.ts#L201)
+Defined in: [types.ts:234](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L234)
 
 The context for the current operation.
 
@@ -13,12 +13,16 @@ The context for the current operation.
 ### contextCarrier
 
 ```ts
-contextCarrier: Record<string, string>;
+contextCarrier: Record<PropertyKey, string>;
 ```
 
-Defined in: [types.ts:215](https://github.com/adobe/aio-lib-telemetry/blob/dd348342643b2b66d5a8c5267221de639b83642e/source/types.ts#L215)
+Defined in: [types.ts:263](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L263)
 
 Holds a carrier that can be used to propagate the active context.
+
+#### Since
+
+0.1.0
 
 ---
 
@@ -28,9 +32,13 @@ Holds a carrier that can be used to propagate the active context.
 currentSpan: Span;
 ```
 
-Defined in: [types.ts:212](https://github.com/adobe/aio-lib-telemetry/blob/dd348342643b2b66d5a8c5267221de639b83642e/source/types.ts#L212)
+Defined in: [types.ts:257](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L257)
 
 The span of the current operation.
+
+#### Since
+
+0.1.0
 
 ---
 
@@ -40,9 +48,13 @@ The span of the current operation.
 logger: AioLogger;
 ```
 
-Defined in: [types.ts:209](https://github.com/adobe/aio-lib-telemetry/blob/dd348342643b2b66d5a8c5267221de639b83642e/source/types.ts#L209)
+Defined in: [types.ts:251](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L251)
 
 The logger for the current operation.
+
+#### Since
+
+0.1.0
 
 ---
 
@@ -52,9 +64,13 @@ The logger for the current operation.
 meter: Meter;
 ```
 
-Defined in: [types.ts:206](https://github.com/adobe/aio-lib-telemetry/blob/dd348342643b2b66d5a8c5267221de639b83642e/source/types.ts#L206)
+Defined in: [types.ts:245](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L245)
 
 The global (managed by the library) meter instance used to create metrics.
+
+#### Since
+
+0.1.0
 
 ---
 
@@ -64,6 +80,10 @@ The global (managed by the library) meter instance used to create metrics.
 tracer: Tracer;
 ```
 
-Defined in: [types.ts:203](https://github.com/adobe/aio-lib-telemetry/blob/dd348342643b2b66d5a8c5267221de639b83642e/source/types.ts#L203)
+Defined in: [types.ts:239](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L239)
 
 The global (managed by the library) tracer instance used to create spans.
+
+#### Since
+
+0.1.0

--- a/docs/api-reference/interfaces/TelemetryApi.md
+++ b/docs/api-reference/interfaces/TelemetryApi.md
@@ -1,6 +1,6 @@
 # `TelemetryApi`
 
-Defined in: [types.ts:216](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L216)
+Defined in: [types.ts:216](https://github.com/adobe/aio-lib-telemetry/blob/8f52cfa8868b711535e2b8726ef8da98982edbdf/source/types.ts#L216)
 
 Defines the global telemetry API. These items should be set once per application.
 
@@ -16,7 +16,7 @@ Defines the global telemetry API. These items should be set once per application
 meter: Meter;
 ```
 
-Defined in: [types.ts:227](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L227)
+Defined in: [types.ts:227](https://github.com/adobe/aio-lib-telemetry/blob/8f52cfa8868b711535e2b8726ef8da98982edbdf/source/types.ts#L227)
 
 The meter used to create metrics.
 
@@ -32,7 +32,7 @@ The meter used to create metrics.
 tracer: Tracer;
 ```
 
-Defined in: [types.ts:221](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L221)
+Defined in: [types.ts:221](https://github.com/adobe/aio-lib-telemetry/blob/8f52cfa8868b711535e2b8726ef8da98982edbdf/source/types.ts#L221)
 
 The tracer used to create spans.
 

--- a/docs/api-reference/interfaces/TelemetryApi.md
+++ b/docs/api-reference/interfaces/TelemetryApi.md
@@ -1,6 +1,6 @@
 # `TelemetryApi`
 
-Defined in: [types.ts:189](https://github.com/adobe/aio-lib-telemetry/blob/dd348342643b2b66d5a8c5267221de639b83642e/source/types.ts#L189)
+Defined in: [types.ts:216](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L216)
 
 Defines the global telemetry API. These items should be set once per application.
 
@@ -16,9 +16,13 @@ Defines the global telemetry API. These items should be set once per application
 meter: Meter;
 ```
 
-Defined in: [types.ts:194](https://github.com/adobe/aio-lib-telemetry/blob/dd348342643b2b66d5a8c5267221de639b83642e/source/types.ts#L194)
+Defined in: [types.ts:227](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L227)
 
 The meter used to create metrics.
+
+#### Since
+
+0.1.0
 
 ---
 
@@ -28,6 +32,10 @@ The meter used to create metrics.
 tracer: Tracer;
 ```
 
-Defined in: [types.ts:191](https://github.com/adobe/aio-lib-telemetry/blob/dd348342643b2b66d5a8c5267221de639b83642e/source/types.ts#L191)
+Defined in: [types.ts:221](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L221)
 
 The tracer used to create spans.
+
+#### Since
+
+0.1.0

--- a/docs/api-reference/interfaces/TelemetryConfig.md
+++ b/docs/api-reference/interfaces/TelemetryConfig.md
@@ -1,6 +1,6 @@
 # `TelemetryConfig`
 
-Defined in: [types.ts:148](https://github.com/adobe/aio-lib-telemetry/blob/dd348342643b2b66d5a8c5267221de639b83642e/source/types.ts#L148)
+Defined in: [types.ts:167](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L167)
 
 The configuration options for the telemetry module.
 
@@ -20,9 +20,13 @@ The configuration options for the telemetry module.
 optional diagnostics: false | TelemetryDiagnosticsConfig;
 ```
 
-Defined in: [types.ts:156](https://github.com/adobe/aio-lib-telemetry/blob/dd348342643b2b66d5a8c5267221de639b83642e/source/types.ts#L156)
+Defined in: [types.ts:180](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L180)
 
 The configuration options for the telemetry diagnostics.
+
+#### Since
+
+0.1.0
 
 ---
 
@@ -32,15 +36,17 @@ The configuration options for the telemetry diagnostics.
 optional meter: Meter;
 ```
 
-Defined in: [types.ts:194](https://github.com/adobe/aio-lib-telemetry/blob/dd348342643b2b66d5a8c5267221de639b83642e/source/types.ts#L194)
+Defined in: [types.ts:227](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L227)
 
 The meter used to create metrics.
 
+#### Since
+
+0.1.0
+
 #### Inherited from
 
-```ts
-Partial.meter;
-```
+[`TelemetryApi`](TelemetryApi.md).[`meter`](TelemetryApi.md#meter)
 
 ---
 
@@ -50,10 +56,14 @@ Partial.meter;
 sdkConfig: Partial<NodeSDKConfiguration>;
 ```
 
-Defined in: [types.ts:153](https://github.com/adobe/aio-lib-telemetry/blob/dd348342643b2b66d5a8c5267221de639b83642e/source/types.ts#L153)
+Defined in: [types.ts:174](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L174)
 
 The configuration options for the OpenTelemetry SDK.
 See the [NodeSDKConfiguration](https://open-telemetry.github.io/opentelemetry-js/interfaces/_opentelemetry_sdk-node.NodeSDKConfiguration.html) interface.
+
+#### Since
+
+0.1.0
 
 ---
 
@@ -63,12 +73,14 @@ See the [NodeSDKConfiguration](https://open-telemetry.github.io/opentelemetry-js
 optional tracer: Tracer;
 ```
 
-Defined in: [types.ts:191](https://github.com/adobe/aio-lib-telemetry/blob/dd348342643b2b66d5a8c5267221de639b83642e/source/types.ts#L191)
+Defined in: [types.ts:221](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L221)
 
 The tracer used to create spans.
 
+#### Since
+
+0.1.0
+
 #### Inherited from
 
-```ts
-Partial.tracer;
-```
+[`TelemetryApi`](TelemetryApi.md).[`tracer`](TelemetryApi.md#tracer)

--- a/docs/api-reference/interfaces/TelemetryConfig.md
+++ b/docs/api-reference/interfaces/TelemetryConfig.md
@@ -1,6 +1,6 @@
 # `TelemetryConfig`
 
-Defined in: [types.ts:167](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L167)
+Defined in: [types.ts:167](https://github.com/adobe/aio-lib-telemetry/blob/8f52cfa8868b711535e2b8726ef8da98982edbdf/source/types.ts#L167)
 
 The configuration options for the telemetry module.
 
@@ -20,7 +20,7 @@ The configuration options for the telemetry module.
 optional diagnostics: false | TelemetryDiagnosticsConfig;
 ```
 
-Defined in: [types.ts:180](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L180)
+Defined in: [types.ts:180](https://github.com/adobe/aio-lib-telemetry/blob/8f52cfa8868b711535e2b8726ef8da98982edbdf/source/types.ts#L180)
 
 The configuration options for the telemetry diagnostics.
 
@@ -36,7 +36,7 @@ The configuration options for the telemetry diagnostics.
 optional meter: Meter;
 ```
 
-Defined in: [types.ts:227](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L227)
+Defined in: [types.ts:227](https://github.com/adobe/aio-lib-telemetry/blob/8f52cfa8868b711535e2b8726ef8da98982edbdf/source/types.ts#L227)
 
 The meter used to create metrics.
 
@@ -56,7 +56,7 @@ The meter used to create metrics.
 sdkConfig: Partial<NodeSDKConfiguration>;
 ```
 
-Defined in: [types.ts:174](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L174)
+Defined in: [types.ts:174](https://github.com/adobe/aio-lib-telemetry/blob/8f52cfa8868b711535e2b8726ef8da98982edbdf/source/types.ts#L174)
 
 The configuration options for the OpenTelemetry SDK.
 See the [NodeSDKConfiguration](https://open-telemetry.github.io/opentelemetry-js/interfaces/_opentelemetry_sdk-node.NodeSDKConfiguration.html) interface.
@@ -73,7 +73,7 @@ See the [NodeSDKConfiguration](https://open-telemetry.github.io/opentelemetry-js
 optional tracer: Tracer;
 ```
 
-Defined in: [types.ts:221](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L221)
+Defined in: [types.ts:221](https://github.com/adobe/aio-lib-telemetry/blob/8f52cfa8868b711535e2b8726ef8da98982edbdf/source/types.ts#L221)
 
 The tracer used to create spans.
 

--- a/docs/api-reference/interfaces/TelemetryDiagnosticsConfig.md
+++ b/docs/api-reference/interfaces/TelemetryDiagnosticsConfig.md
@@ -1,6 +1,6 @@
 # `TelemetryDiagnosticsConfig`
 
-Defined in: [types.ts:41](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L41)
+Defined in: [types.ts:41](https://github.com/adobe/aio-lib-telemetry/blob/8f52cfa8868b711535e2b8726ef8da98982edbdf/source/types.ts#L41)
 
 The configuration for the telemetry diagnostics.
 
@@ -16,7 +16,7 @@ The configuration for the telemetry diagnostics.
 optional exportLogs: boolean;
 ```
 
-Defined in: [types.ts:63](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L63)
+Defined in: [types.ts:63](https://github.com/adobe/aio-lib-telemetry/blob/8f52cfa8868b711535e2b8726ef8da98982edbdf/source/types.ts#L63)
 
 Whether to make OpenTelemetry also export the diagnostic logs to the configured exporters.
 Set to `false` if you don't want to see diagnostic logs in your observability platform.
@@ -39,7 +39,7 @@ true;
 optional loggerName: string;
 ```
 
-Defined in: [types.ts:54](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L54)
+Defined in: [types.ts:54](https://github.com/adobe/aio-lib-telemetry/blob/8f52cfa8868b711535e2b8726ef8da98982edbdf/source/types.ts#L54)
 
 The name of the logger to use for the diagnostics.
 
@@ -59,7 +59,7 @@ The name of the logger to use for the diagnostics.
 logLevel: "info" | "error" | "none" | "warn" | "debug" | "verbose" | "all";
 ```
 
-Defined in: [types.ts:46](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L46)
+Defined in: [types.ts:46](https://github.com/adobe/aio-lib-telemetry/blob/8f52cfa8868b711535e2b8726ef8da98982edbdf/source/types.ts#L46)
 
 The log level to use for the diagnostics.
 

--- a/docs/api-reference/interfaces/TelemetryDiagnosticsConfig.md
+++ b/docs/api-reference/interfaces/TelemetryDiagnosticsConfig.md
@@ -1,6 +1,6 @@
 # `TelemetryDiagnosticsConfig`
 
-Defined in: [types.ts:44](https://github.com/adobe/aio-lib-telemetry/blob/dd348342643b2b66d5a8c5267221de639b83642e/source/types.ts#L44)
+Defined in: [types.ts:41](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L41)
 
 The configuration for the telemetry diagnostics.
 
@@ -16,7 +16,7 @@ The configuration for the telemetry diagnostics.
 optional exportLogs: boolean;
 ```
 
-Defined in: [types.ts:59](https://github.com/adobe/aio-lib-telemetry/blob/dd348342643b2b66d5a8c5267221de639b83642e/source/types.ts#L59)
+Defined in: [types.ts:63](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L63)
 
 Whether to make OpenTelemetry also export the diagnostic logs to the configured exporters.
 Set to `false` if you don't want to see diagnostic logs in your observability platform.
@@ -27,6 +27,10 @@ Set to `false` if you don't want to see diagnostic logs in your observability pl
 true;
 ```
 
+#### Since
+
+0.1.0
+
 ---
 
 ### loggerName?
@@ -35,13 +39,17 @@ true;
 optional loggerName: string;
 ```
 
-Defined in: [types.ts:52](https://github.com/adobe/aio-lib-telemetry/blob/dd348342643b2b66d5a8c5267221de639b83642e/source/types.ts#L52)
+Defined in: [types.ts:54](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L54)
 
 The name of the logger to use for the diagnostics.
 
 #### Default
 
 `${actionName}/otel-diagnostics`
+
+#### Since
+
+0.1.0
 
 ---
 
@@ -51,6 +59,10 @@ The name of the logger to use for the diagnostics.
 logLevel: "info" | "error" | "none" | "warn" | "debug" | "verbose" | "all";
 ```
 
-Defined in: [types.ts:46](https://github.com/adobe/aio-lib-telemetry/blob/dd348342643b2b66d5a8c5267221de639b83642e/source/types.ts#L46)
+Defined in: [types.ts:46](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L46)
 
 The log level to use for the diagnostics.
+
+#### Since
+
+0.1.0

--- a/docs/api-reference/interfaces/TelemetryPropagationConfig.md
+++ b/docs/api-reference/interfaces/TelemetryPropagationConfig.md
@@ -1,6 +1,6 @@
 # `TelemetryPropagationConfig`
 
-Defined in: [types.ts:70](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L70)
+Defined in: [types.ts:70](https://github.com/adobe/aio-lib-telemetry/blob/8f52cfa8868b711535e2b8726ef8da98982edbdf/source/types.ts#L70)
 
 Configuration related to context propagation (for distributed tracing).
 
@@ -19,16 +19,16 @@ optional getContextCarrier: (params: Record<string, unknown>) => {
 };
 ```
 
-Defined in: [types.ts:89](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L89)
+Defined in: [types.ts:89](https://github.com/adobe/aio-lib-telemetry/blob/8f52cfa8868b711535e2b8726ef8da98982edbdf/source/types.ts#L89)
 
 A function that returns the carrier for the current context.
 Use it to specify where your carrier is located in the incoming parameters, when it's not one of the defaults.
 
 #### Parameters
 
-| Parameter | Type                            |
-| --------- | ------------------------------- |
-| `params`  | `Record`\<`string`, `unknown`\> |
+| Parameter | Type                            | Description                                                    |
+| --------- | ------------------------------- | -------------------------------------------------------------- |
+| `params`  | `Record`\<`string`, `unknown`\> | The classic `params` object received by Adobe runtime actions. |
 
 #### Returns
 
@@ -65,7 +65,7 @@ carrier: Record<PropertyKey, string>;
 optional skip: boolean;
 ```
 
-Defined in: [types.ts:78](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L78)
+Defined in: [types.ts:78](https://github.com/adobe/aio-lib-telemetry/blob/8f52cfa8868b711535e2b8726ef8da98982edbdf/source/types.ts#L78)
 
 By default, an instrumented entrypoint will try to automatically read (and use) the context from the incoming request.
 Set to `true` if you want to skip this automatic context propagation.

--- a/docs/api-reference/interfaces/TelemetryPropagationConfig.md
+++ b/docs/api-reference/interfaces/TelemetryPropagationConfig.md
@@ -1,6 +1,6 @@
-# `TelemetryPropagationConfig\<T\>`
+# `TelemetryPropagationConfig`
 
-Defined in: [types.ts:66](https://github.com/adobe/aio-lib-telemetry/blob/dd348342643b2b66d5a8c5267221de639b83642e/source/types.ts#L66)
+Defined in: [types.ts:70](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L70)
 
 Configuration related to context propagation (for distributed tracing).
 
@@ -8,40 +8,34 @@ Configuration related to context propagation (for distributed tracing).
 
 0.1.0
 
-## Type Parameters
-
-| Type Parameter              |
-| --------------------------- |
-| `T` _extends_ `AnyFunction` |
-
 ## Properties
 
 ### getContextCarrier()?
 
 ```ts
-optional getContextCarrier: (...args: Parameters<T>) => {
+optional getContextCarrier: (params: Record<string, unknown>) => {
   baseCtx?: Context;
-  carrier: Record<string, string>;
+  carrier: Record<PropertyKey, string>;
 };
 ```
 
-Defined in: [types.ts:82](https://github.com/adobe/aio-lib-telemetry/blob/dd348342643b2b66d5a8c5267221de639b83642e/source/types.ts#L82)
+Defined in: [types.ts:89](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L89)
 
 A function that returns the carrier for the current context.
 Use it to specify where your carrier is located in the incoming parameters, when it's not one of the defaults.
 
 #### Parameters
 
-| Parameter | Type                | Description                                 |
-| --------- | ------------------- | ------------------------------------------- |
-| ...`args` | `Parameters`\<`T`\> | The arguments of the instrumented function. |
+| Parameter | Type                            |
+| --------- | ------------------------------- |
+| `params`  | `Record`\<`string`, `unknown`\> |
 
 #### Returns
 
 ```ts
 {
   baseCtx?: Context;
-  carrier: Record<string, string>;
+  carrier: Record<PropertyKey, string>;
 }
 ```
 
@@ -56,8 +50,12 @@ optional baseCtx: Context;
 ##### carrier
 
 ```ts
-carrier: Record<string, string>;
+carrier: Record<PropertyKey, string>;
 ```
+
+#### Since
+
+0.1.0
 
 ---
 
@@ -67,7 +65,7 @@ carrier: Record<string, string>;
 optional skip: boolean;
 ```
 
-Defined in: [types.ts:73](https://github.com/adobe/aio-lib-telemetry/blob/dd348342643b2b66d5a8c5267221de639b83642e/source/types.ts#L73)
+Defined in: [types.ts:78](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L78)
 
 By default, an instrumented entrypoint will try to automatically read (and use) the context from the incoming request.
 Set to `true` if you want to skip this automatic context propagation.
@@ -77,3 +75,7 @@ Set to `true` if you want to skip this automatic context propagation.
 ```ts
 false;
 ```
+
+#### Since
+
+0.1.0

--- a/docs/api-reference/type-aliases/DiagnosticsLogLevel.md
+++ b/docs/api-reference/type-aliases/DiagnosticsLogLevel.md
@@ -4,7 +4,7 @@
 type DiagnosticsLogLevel = Lowercase<keyof typeof DiagLogLevel>;
 ```
 
-Defined in: [types.ts:32](https://github.com/adobe/aio-lib-telemetry/blob/dd348342643b2b66d5a8c5267221de639b83642e/source/types.ts#L32)
+Defined in: [types.ts:29](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L29)
 
 Available log levels for the OpenTelemetry `DiagLogger`.
 

--- a/docs/api-reference/type-aliases/DiagnosticsLogLevel.md
+++ b/docs/api-reference/type-aliases/DiagnosticsLogLevel.md
@@ -4,7 +4,7 @@
 type DiagnosticsLogLevel = Lowercase<keyof typeof DiagLogLevel>;
 ```
 
-Defined in: [types.ts:29](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L29)
+Defined in: [types.ts:29](https://github.com/adobe/aio-lib-telemetry/blob/8f52cfa8868b711535e2b8726ef8da98982edbdf/source/types.ts#L29)
 
 Available log levels for the OpenTelemetry `DiagLogger`.
 

--- a/docs/api-reference/type-aliases/TelemetryInstrumentationPreset.md
+++ b/docs/api-reference/type-aliases/TelemetryInstrumentationPreset.md
@@ -4,7 +4,7 @@
 type TelemetryInstrumentationPreset = "simple" | "full";
 ```
 
-Defined in: [types.ts:35](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L35)
+Defined in: [types.ts:35](https://github.com/adobe/aio-lib-telemetry/blob/8f52cfa8868b711535e2b8726ef8da98982edbdf/source/types.ts#L35)
 
 Defines the names of available instrumentation presets.
 

--- a/docs/api-reference/type-aliases/TelemetryInstrumentationPreset.md
+++ b/docs/api-reference/type-aliases/TelemetryInstrumentationPreset.md
@@ -4,7 +4,7 @@
 type TelemetryInstrumentationPreset = "simple" | "full";
 ```
 
-Defined in: [types.ts:38](https://github.com/adobe/aio-lib-telemetry/blob/dd348342643b2b66d5a8c5267221de639b83642e/source/types.ts#L38)
+Defined in: [types.ts:35](https://github.com/adobe/aio-lib-telemetry/blob/9592ef0d673b0c1c4209408c0de01f199de38283/source/types.ts#L35)
 
 Defines the names of available instrumentation presets.
 

--- a/source/types.ts
+++ b/source/types.ts
@@ -83,7 +83,7 @@ export interface TelemetryPropagationConfig {
    *
    * @since 0.1.0
    *
-   * @param args - The arguments of the instrumented function.
+   * @param params - The classic `params` object received by Adobe runtime actions.
    * @returns The carrier of the context to retrieve and an optional base context to use for the started span (defaults to the active context).
    */
   getContextCarrier?: (params: Record<string, unknown>) => {

--- a/tests/unit/api/presets.test.ts
+++ b/tests/unit/api/presets.test.ts
@@ -10,10 +10,10 @@
  * governing permissions and limitations under the License.
  */
 
+import { HttpInstrumentation } from "@opentelemetry/instrumentation-http";
 import { UndiciInstrumentation } from "@opentelemetry/instrumentation-undici";
 import { beforeEach, describe, expect, test } from "vitest";
 
-import type { HttpInstrumentation } from "@opentelemetry/instrumentation-http";
 import type { TelemetryInstrumentationPreset } from "~/types";
 
 describe("api/presets", () => {
@@ -70,9 +70,7 @@ describe("api/presets", () => {
         );
 
         expect(httpInstrumentation).toBeDefined();
-
-        // Temporarily commenting because of an instance mismatch between package versions.
-        // expect(httpInstrumentation).toBeInstanceOf(HttpInstrumentation);
+        expect(httpInstrumentation).toBeInstanceOf(HttpInstrumentation);
 
         const config = (httpInstrumentation as HttpInstrumentation).getConfig();
         expect(config.requireParentforIncomingSpans).toBe(true);


### PR DESCRIPTION
This PR uncomments an `expect` from a test that caused issues due to a dependency mismatch. It also fixes a JSDoc typo and regenerates the api reference.