### PR TITLE
chore: improve renovate config with automerge for safe updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,10 +8,10 @@
     "group:monorepos",
     "group:definitelyTyped",
     "helpers:disableTypesNodeMajor",
+    "helpers:pinGitHubActionDigestsToSemver",
     "security:minimumReleaseAgeNpm",
     ":automergeDisabled",
     ":ignoreUnstable",
-    ":maintainLockFilesWeekly",
     ":prConcurrentLimitNone",
     ":preserveSemverRanges",
     ":rebaseStalePrs",
@@ -20,23 +20,31 @@
     ":separateMultipleMajorReleases"
   ],
   "automerge": false,
+  "vulnerabilityAlerts": {
+    "automerge": true
+  },
+  "osvVulnerabilityAlerts": true,
   "branchPrefix": "renovate/",
   "commitMessagePrefix": "chore(renovate): ",
   "labels": ["dependencies"],
   "postUpdateOptions": ["npmDedupe"],
   "packageRules": [
     {
-      "matchManagers": ["github-actions"],
-      "pinDigests": false
+      "groupName": "all non-major dependencies",
+      "groupSlug": "all-non-major",
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true,
+      "schedule": ["on Monday"]
     },
     {
-      "groupName": "OpenTelemetry packages",
-      "matchUpdateTypes": ["minor", "patch"],
-      "matchPackageNames": ["/^@opentelemetry//"]
+      "matchUpdateTypes": ["lockFileMaintenance"],
+      "automerge": true,
+      "schedule": ["on Monday"]
     },
     {
       "groupName": "biome and ultracite",
       "matchPackageNames": ["@biomejs/biome", "ultracite"],
+      "automerge": true,
       "separateMajorMinor": false,
       "postUpgradeTasks": {
         "commands": ["npm run lint:fix", "npm run format"],


### PR DESCRIPTION
## Summary

Improves the Renovate configuration to automate safe dependency updates while keeping manual review for risky ones.

### Changes

- **`helpers:pinGitHubActionDigestsToSemver`** — pins GitHub Actions to semver digests instead of disabling digest pinning
- **`vulnerabilityAlerts` + `osvVulnerabilityAlerts`** — security vulnerability PRs are automerged immediately
- **Replaced `:maintainLockFilesWeekly`** with an explicit `lockFileMaintenance` packageRule — same behavior but grouped with Monday schedule and automerge
- **"all non-major dependencies" rule** — groups all minor/patch updates into one automerged PR on Mondays
- **"biome and ultracite" rule** — automerges biome/ultracite updates (all versions) after running `lint:fix` and `format` to apply any new rules automatically; `separateMajorMinor: false` keeps them in a single PR
- **Removed** the `github-actions` `pinDigests: false` rule (superseded by the new preset) and the `OpenTelemetry packages` grouping rule (covered by the catch-all non-major rule)

🤖 Generated with [Claude Code](https://claude.com/claude-code)