### PR TITLE
chore: bump ultracite to 7.9.3

### DIFF
--- a/.github/scripts/announce.ts
+++ b/.github/scripts/announce.ts
@@ -45,11 +45,11 @@ function main() {
   const webhookBody = JSON.stringify({
     blocks: [
       {
-        type: "section",
         text: {
-          type: "mrkdwn",
           text: announcement,
+          type: "mrkdwn",
         },
+        type: "section",
       },
     ],
   });

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -62,6 +62,19 @@
           }
         }
       }
+    },
+    {
+      "includes": ["source/api/propagation.ts"],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            // False positive: Biome infers property access on the untyped
+            // Record<string, unknown> action params as guaranteed non-nullish,
+            // but these runtime keys are genuinely optional.
+            "noUnnecessaryConditions": "off"
+          }
+        }
+      }
     }
   ],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "winston-transport": "^4.9.0"
       },
       "devDependencies": {
-        "@biomejs/biome": "^2.4.15",
+        "@biomejs/biome": "^2.5.2",
         "@changesets/changelog-github": "0.7.0",
         "@changesets/cli": "2.31.0",
         "@tsconfig/node-lts": "^24.0.0",
@@ -57,7 +57,7 @@
         "typedoc": "^0.28.19",
         "typedoc-plugin-markdown": "^4.11.0",
         "typescript": "^6.0.3",
-        "ultracite": "7.8.4",
+        "ultracite": "^7.9.3",
         "vite-tsconfig-paths": "^6.1.1",
         "vitest": "^4.1.6"
       },
@@ -760,6 +760,148 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.5",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@eslint/core": "^1.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@eslint/core": "^1.2.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
     "node_modules/@gerrit0/mini-shiki": {
       "version": "3.23.0",
       "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.23.0.tgz",
@@ -803,6 +945,77 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@inquirer/external-editor": {
@@ -3617,6 +3830,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -3640,6 +3861,14 @@
       "integrity": "sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/memcached": {
       "version": "2.2.10",
@@ -3718,6 +3947,199 @@
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.63.0.tgz",
+      "integrity": "sha512-e5dh0/UI0ok53AlZ5wRkXCB32z/f2jUZqPR/ygAw5WYaSw8j9EoJWlS7wQjr/dmOaqWjnPIn2m+HhVPCMWGZVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.63.0",
+        "@typescript-eslint/types": "^8.63.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.63.0.tgz",
+      "integrity": "sha512-uUyfMWCnDSN8bCpcrY8nGP2BLkQ9Xn0GsipcONcpIDWhwhO4ZSyHvyS14U3X75mzxWxL3I2UZIrenTzdzcJO8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.63.0",
+        "@typescript-eslint/visitor-keys": "8.63.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.63.0.tgz",
+      "integrity": "sha512-sUAbkulqBAsncKnbRP3+7CtQFRKicexnj7ZwNC6ddCR7EmrXvjvdCYMJbUIqMd6lwoEriZjwLo08aS5tSjVMHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.63.0.tgz",
+      "integrity": "sha512-xyLtl9DUBBFrcJS4x2pIqGLH68/tC2uOa4Z7pUteW09D3bXnnXUom4dyPikzWgB7llmIc1zoeI3aoUdC4rPK/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.63.0.tgz",
+      "integrity": "sha512-ygBkU+B7ex5UI/gKhaqexWev79uISfIv7XQCRNYO/jmD8rGLPyWLAb3KMRT6nd8Gt9bmUBi9+iX6tBdYfOY81Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.63.0",
+        "@typescript-eslint/tsconfig-utils": "8.63.0",
+        "@typescript-eslint/types": "8.63.0",
+        "@typescript-eslint/visitor-keys": "8.63.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.63.0.tgz",
+      "integrity": "sha512-fUKaeAvrTuQg/Tgt3nliAUSZHJM6DlCcfyEmxCvlX8kieWSStBX+5O5Fnidtc3i2JrH+9c/GL4RY2iasd/GPTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.63.0",
+        "@typescript-eslint/types": "8.63.0",
+        "@typescript-eslint/typescript-estree": "8.63.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.63.0.tgz",
+      "integrity": "sha512-UexrHGnGTpbuQHct2ExOc2ZcFbGUS9FOesCxxqdBGcpI1BxYu/LZ6U8Aq6/72XtF/qRBk9nhuGHFJIXXMhPMdw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.63.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
     },
     "node_modules/@vitest/coverage-v8": {
       "version": "4.1.9",
@@ -3885,6 +4307,31 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -3892,6 +4339,24 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/ansi-colors": {
@@ -4394,6 +4859,14 @@
         }
       }
     },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/deepmerge": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -4557,6 +5030,285 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.6.0.tgz",
+      "integrity": "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "workspaces": [
+        "packages/*"
+      ],
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.6.0",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.2",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/eslint/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/eslint/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -4571,6 +5323,45 @@
         "node": ">=4"
       }
     },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -4579,6 +5370,17 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/eventemitter3": {
@@ -4611,6 +5413,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/fast-glob": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
@@ -4627,6 +5437,22 @@
       "engines": {
         "node": ">=8.6.0"
       }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/fast-string-truncated-width": {
       "version": "3.0.3",
@@ -4729,6 +5555,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -4754,6 +5594,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/flatted": {
@@ -5126,6 +5981,17 @@
         "url": "https://github.com/sponsors/sxzz"
       }
     },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -5338,6 +6204,30 @@
         "bignumber.js": "^9.0.0"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/jsonc-parser": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
@@ -5353,6 +6243,17 @@
       "license": "MIT",
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "json-buffer": "3.0.1"
       }
     },
     "node_modules/knip": {
@@ -5399,6 +6300,21 @@
       "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
       "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
       "license": "MIT"
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
@@ -6092,6 +7008,14 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/node-domexception": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
@@ -6188,6 +7112,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/outdent": {
@@ -6525,6 +7468,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/prettier": {
       "version": "3.9.4",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.4.tgz",
@@ -6592,6 +7546,17 @@
       "integrity": "sha512-xg1eHpwYL/D/HEdWw2goFZP6vV0FH7W+PZ5rFkGjdIDLtxq7EkzBUeT3m+lndYCt8wKbmofUu1MUdMCXkCk9ZQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/punycode.js": {
       "version": "2.3.1",
@@ -7442,6 +8407,19 @@
         "node": ">= 14.0.0"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/tsdown": {
       "version": "0.22.3",
       "resolved": "https://registry.npmjs.org/tsdown/-/tsdown-0.22.3.tgz",
@@ -7522,6 +8500,20 @@
       "dev": true,
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/typedoc": {
       "version": "0.28.20",
@@ -7621,13 +8613,14 @@
       "license": "MIT"
     },
     "node_modules/ultracite": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/ultracite/-/ultracite-7.8.4.tgz",
-      "integrity": "sha512-Lqd1k8sr7xT3QY+2x6qA72TFkA3r1Z7QvCUbOFBOeGAVdwBG43RPSvhTuEpZOgbdINFBcJ/v6dK2tyT4inPDTQ==",
+      "version": "7.9.3",
+      "resolved": "https://registry.npmjs.org/ultracite/-/ultracite-7.9.3.tgz",
+      "integrity": "sha512-MqF0cn5DNHy/I61+hL4aYPRVye+rrmUqfv1dhwQ0ORfoFngk1O8tTKigF+zpsh/6qA84gkl26KkrtYzoypPiaw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.5.1",
+        "@typescript-eslint/utils": "^8.62.1",
         "commander": "^15.0.0",
         "cross-spawn": "^7.0.6",
         "deepmerge": "^4.3.1",
@@ -7792,6 +8785,17 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -8126,6 +9130,17 @@
         "node": ">= 12.0.0"
       }
     },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/wrap-ansi": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-10.0.0.tgz",
@@ -8328,6 +9343,20 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "winston-transport": "^4.9.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.4.15",
+    "@biomejs/biome": "^2.5.2",
     "@changesets/changelog-github": "0.7.0",
     "@changesets/cli": "2.31.0",
     "@tsconfig/node-lts": "^24.0.0",
@@ -132,7 +132,7 @@
     "typedoc": "^0.28.19",
     "typedoc-plugin-markdown": "^4.11.0",
     "typescript": "^6.0.3",
-    "ultracite": "7.8.4",
+    "ultracite": "^7.9.3",
     "vite-tsconfig-paths": "^6.1.1",
     "vitest": "^4.1.6"
   },

--- a/source/api/presets.ts
+++ b/source/api/presets.ts
@@ -21,9 +21,9 @@ import type { UndiciInstrumentationConfig } from "@opentelemetry/instrumentation
 import type { TelemetryInstrumentationPreset } from "~/types";
 
 const httpInstrumentationConfig = {
+  disableIncomingRequestInstrumentation: true,
   // Prevent traces from being created by the un-managed logic of `aio app dev`.
   requireParentforIncomingSpans: true,
-  disableIncomingRequestInstrumentation: true,
 } satisfies HttpInstrumentationConfig;
 
 const undiciInstrumentationConfig = {

--- a/source/api/propagation.ts
+++ b/source/api/propagation.ts
@@ -73,12 +73,12 @@ function inferContextCarrier(params: Record<string, unknown>) {
   // 1. A `x-telemetry-context` header.
   // 2. A `__telemetryContext` input parameter.
   // 3. A `__telemetryContext` property in `params.data`.
-  const headers = params.__ow_headers as Record<string, string>;
+  const headers = params.__ow_headers as Record<string, string> | undefined;
   const telemetryContext =
     // @deprecated: Remove custom __telemetryContext lookups in a future major release.
     headers?.["x-telemetry-context"] ??
     params.__telemetryContext ??
-    (params.data as Record<string, unknown>)?.__telemetryContext ??
+    (params.data as Record<string, unknown> | undefined)?.__telemetryContext ??
     null;
 
   // If the telemetry context is not found among all the above lookups,

--- a/source/core/instrumentation.ts
+++ b/source/core/instrumentation.ts
@@ -163,8 +163,8 @@ export function instrument<T extends AnyFunction>(
 
       const exception = {
         code: UNKNOWN_ERROR_CODE,
-        name: UNKNOWN_ERROR_NAME,
         message: `Unhandled error at span "${spanName}": ${error}`,
+        name: UNKNOWN_ERROR_NAME,
         stack: stackCarrier.stack,
       };
 
@@ -182,16 +182,16 @@ export function instrument<T extends AnyFunction>(
     const { actionName } = getRuntimeActionMetadata();
     const { tracer, meter } = getGlobalTelemetryApi();
     const logger = getLogger(`${actionName}/${spanName}`, {
-      logSourceAction: false,
       level: process.env.__AIO_LIB_TELEMETRY_LOG_LEVEL,
+      logSourceAction: false,
     });
 
     return {
+      contextCarrier: carrier,
       currentSpan: span,
       logger,
-      tracer,
       meter,
-      contextCarrier: carrier,
+      tracer,
     } satisfies InstrumentationHelpers;
   }
 
@@ -293,7 +293,7 @@ export function instrumentEntrypoint<
 
     // Internal calls to initialize the Telemetry SDK.
     initializeSdk(sdkConfig);
-    initializeGlobalTelemetryApi({ tracer, meter });
+    initializeGlobalTelemetryApi({ meter, tracer });
 
     const { propagation, ...instrumentationConfig } =
       applyInstrumentationIntegrationPatches(

--- a/source/core/logging.ts
+++ b/source/core/logging.ts
@@ -49,10 +49,10 @@ function __getLoggerInternal({
   const level = config?.level ?? DEFAULT_LOG_LEVEL;
   const aioLogger = AioLogger(name, {
     ...config,
+    level,
 
     // Provider must be winston, as it's the one compatible with OpenTelemetry.
     provider: "winston",
-    level,
   });
 
   if (addTransport) {
@@ -84,7 +84,7 @@ function __getLoggerInternal({
  * ```
  */
 export function getLogger(name: string, config?: AioLoggerConfig) {
-  return __getLoggerInternal({ name, config, forceSDKInitialized: true });
+  return __getLoggerInternal({ config, forceSDKInitialized: true, name });
 }
 
 /**
@@ -100,20 +100,20 @@ export function setOtelDiagLogger({
   const logLevels: Partial<
     Record<TelemetryDiagnosticsConfig["logLevel"], string>
   > = {
-    none: undefined,
     all: "verbose",
+    none: undefined,
   };
 
   const aioLogLevel = logLevels[level] ?? level;
   const { actionName } = getRuntimeActionMetadata();
   const logger = __getLoggerInternal({
-    name: loggerName ?? `${actionName}/otel-diagnostics`,
+    addTransport: exportLogs,
     config: {
       level: aioLogLevel,
       logSourceAction: false,
     },
     forceSDKInitialized: false,
-    addTransport: exportLogs,
+    name: loggerName ?? `${actionName}/otel-diagnostics`,
 
     // Only use the OpenTelemetry transport (i.e. export diagnostic logs) if the log level is
     // set to info, warn or error. The other levels are too verbose to be exported and may expose

--- a/source/core/telemetry-api.ts
+++ b/source/core/telemetry-api.ts
@@ -75,5 +75,5 @@ export function initializeGlobalTelemetryApi(
     meter = metrics.getMeter(actionName, actionVersion),
   } = config;
 
-  setGlobalTelemetryApi({ tracer, meter });
+  setGlobalTelemetryApi({ meter, tracer });
 }

--- a/source/helpers/integrations.ts
+++ b/source/helpers/integrations.ts
@@ -48,8 +48,8 @@ export function applyInstrumentationIntegrationPatches(
     for (const integration of integrations) {
       currentIntegration = integration.name;
       integration.patchInstrumentationConfig?.({
-        params,
         instrumentationConfig: initialInstrumentationConfig,
+        params,
         updateInstrumentationConfig: updateInstrumentationConfigHandler,
       });
     }

--- a/source/helpers/runtime.ts
+++ b/source/helpers/runtime.ts
@@ -59,21 +59,21 @@ export function isTelemetryEnabled() {
 /** Retrieves basic metadata from the runtime environment. */
 function retrieveBasicMetadata() {
   return {
+    actionVersion: process.env.__OW_ACTION_VERSION ?? "0.0.0 (development)",
     activationId: process.env.__OW_ACTIVATION_ID as string,
-    namespace: process.env.__OW_NAMESPACE as string,
     apiHost: process.env.__OW_API_HOST as string,
     apiKey: process.env.__OW_API_KEY as string,
+    cloud: process.env.__OW_CLOUD ?? "local",
+    deadline: process.env.__OW_DEADLINE
+      ? new Date(Number(process.env.__OW_DEADLINE))
+      : null,
     isDevelopment: isDevelopment(),
+    namespace: process.env.__OW_NAMESPACE as string,
 
     // The following are only set on production
     // We provide some arbitrary values for local development
     region: process.env.__OW_REGION ?? "local",
-    cloud: process.env.__OW_CLOUD ?? "local",
     transactionId: process.env.__OW_TRANSACTION_ID ?? "unknown",
-    actionVersion: process.env.__OW_ACTION_VERSION ?? "0.0.0 (development)",
-    deadline: process.env.__OW_DEADLINE
-      ? new Date(Number(process.env.__OW_DEADLINE))
-      : null,
   };
 }
 
@@ -83,24 +83,24 @@ function parseActionName() {
 
   if (!actionName) {
     return {
-      packageName: "unknown",
       actionName: "unknown",
+      packageName: "unknown",
     };
   }
 
   if (actionName.includes("/")) {
     const [, _, packageName, ...action] = actionName.split("/");
     return {
-      packageName,
       actionName: action.join("/"),
+      packageName,
     };
   }
 
   return {
+    actionName: process.env.__OW_ACTION_NAME as string,
     // Old installations of AIO CLI, might use a version `aio app dev`
     // where ACTION_NAME doesn't include a package name.
     packageName: "unknown",
-    actionName: process.env.__OW_ACTION_NAME as string,
   };
 }
 
@@ -133,11 +133,11 @@ function createServiceName(meta: RuntimeMetadata) {
 function createCoreAttributes(meta: RuntimeMetadata) {
   return {
     [ATTR_SERVICE_NAME]: createServiceName(meta),
-    environment: meta.isDevelopment ? "development" : "production",
+    "action.activation_id": meta.activationId,
 
     "action.name": meta.actionName,
     "action.namespace": meta.namespace,
-    "action.activation_id": meta.activationId,
+    environment: meta.isDevelopment ? "development" : "production",
   };
 }
 
@@ -164,8 +164,8 @@ function addKnownValueAttributes(
   meta: RuntimeMetadata,
 ) {
   const potentiallyUnknownAttributes = {
-    "action.transaction_id": meta.transactionId,
     "action.package_name": meta.packageName,
+    "action.transaction_id": meta.transactionId,
   };
 
   for (const [name, value] of Object.entries(potentiallyUnknownAttributes)) {

--- a/source/integrations/commerce.ts
+++ b/source/integrations/commerce.ts
@@ -127,8 +127,8 @@ export function commerceWebhooks({
 
       updateInstrumentationConfig({
         propagation: {
+          getContextCarrier: () => ({ baseCtx: propagatedCtx, carrier }),
           skip: shouldCreateNewRoot,
-          getContextCarrier: () => ({ carrier, baseCtx: propagatedCtx }),
         },
 
         spanConfig: {

--- a/tests/unit/api/attributes.test.ts
+++ b/tests/unit/api/attributes.test.ts
@@ -53,8 +53,8 @@ describe("api/attributes", () => {
   describe("getAioRuntimeResourceWithAttributes", () => {
     test("should merge custom attributes with runtime attributes", () => {
       const customAttributes = {
-        foo: "bar",
         baz: "qux",
+        foo: "bar",
       };
 
       const resource =
@@ -68,17 +68,17 @@ describe("api/attributes", () => {
 
     test("should override runtime attributes with custom attributes", () => {
       const customAttributes = {
-        "some.attribute": "custom-value",
         custom: "value",
+        "some.attribute": "custom-value",
       };
 
       const resource =
         attributesApi.getAioRuntimeResourceWithAttributes(customAttributes);
 
       expect(resource.attributes).toMatchObject({
+        custom: "value",
         "some.attribute": "custom-value",
         "some.other.attribute": "test-value-2",
-        custom: "value",
       });
     });
 

--- a/tests/unit/api/global.test.ts
+++ b/tests/unit/api/global.test.ts
@@ -20,9 +20,9 @@ describe("api/global", () => {
   const mockContext = {} as Context;
   const mockSpan = {
     addEvent: vi.fn(),
+    end: vi.fn(),
     recordException: vi.fn(),
     setStatus: vi.fn(),
-    end: vi.fn(),
   } as unknown as Span;
 
   const mockContextActive = vi.fn(() => mockContext);
@@ -121,7 +121,7 @@ describe("api/global", () => {
     });
 
     test("should add an event with attributes to the active span", () => {
-      const attributes = { foo: "bar", baz: 42 };
+      const attributes = { baz: 42, foo: "bar" };
       mockContextActive.mockReturnValueOnce(mockContext);
       mockTraceGetSpan.mockReturnValueOnce(mockSpan);
 
@@ -152,7 +152,7 @@ describe("api/global", () => {
     });
 
     test("should add an event with attributes and return true", () => {
-      const attributes = { foo: "bar", baz: 42 };
+      const attributes = { baz: 42, foo: "bar" };
       mockContextActive.mockReturnValueOnce(mockContext);
       mockTraceGetSpan.mockReturnValueOnce(mockSpan);
 

--- a/tests/unit/api/propagation.test.ts
+++ b/tests/unit/api/propagation.test.ts
@@ -25,19 +25,18 @@ describe("api/propagation", () => {
     }
 
     return {
+      deleteValue: vi.fn((key) => {
+        const newState = new Map(state);
+        newState.delete(key);
+
+        return createMockContext();
+      }),
       getValue: vi.fn((key) => state.get(key)),
       setValue: vi.fn((key, value) => {
         const newState = new Map(state);
         newState.set(key, value);
 
         return createMockContext(value);
-      }),
-
-      deleteValue: vi.fn((key) => {
-        const newState = new Map(state);
-        newState.delete(key);
-
-        return createMockContext();
       }),
     } as Context;
   };
@@ -49,20 +48,18 @@ describe("api/propagation", () => {
     vi.clearAllMocks();
 
     vi.doMock("@opentelemetry/api", () => ({
+      context: {
+        active: mockActiveContextGetter,
+      },
       propagation: {
-        inject: vi.fn((ctx, carrier) => {
-          carrier["x-test"] = ctx.getValue(testKey) ?? "";
-        }),
-
         extract: vi.fn((ctx, carrier) =>
           ctx.setValue(testKey, carrier["x-test"]),
         ),
 
         fields: vi.fn(() => ["x-test"]),
-      },
-
-      context: {
-        active: mockActiveContextGetter,
+        inject: vi.fn((ctx, carrier) => {
+          carrier["x-test"] = ctx.getValue(testKey) ?? "";
+        }),
       },
     }));
 
@@ -119,8 +116,8 @@ describe("api/propagation", () => {
 
     test("does not modify carrier", () => {
       const carrier = {
-        "x-test": "original",
         untouched: "yes",
+        "x-test": "original",
       };
 
       const resultCtx = propagationApi.deserializeContextFromCarrier(carrier);

--- a/tests/unit/core/config.test.ts
+++ b/tests/unit/core/config.test.ts
@@ -33,9 +33,9 @@ describe("core/config", () => {
 
     test("should work with async initialization functions", () => {
       const asyncInitFn = vi.fn().mockImplementation(async () => ({
+        meter: {} as Meter,
         sdkConfig: await new Promise((resolve) => resolve({})),
         tracer: {} as Tracer,
-        meter: {} as Meter,
       }));
 
       const config = coreConfig.defineTelemetryConfig(asyncInitFn);

--- a/tests/unit/core/instrumentation.test.ts
+++ b/tests/unit/core/instrumentation.test.ts
@@ -38,28 +38,28 @@ describe("core/instrumentation", () => {
     tracer = trace.getTracer("test-tracer");
     meter = metrics.getMeter("test-meter");
     vi.stubGlobal("__OTEL_TELEMETRY_API__", {
-      tracer,
       meter,
+      tracer,
     });
 
     vi.doMock("~/helpers/runtime", () => ({
       getRuntimeActionMetadata: vi.fn(() => ({
         actionName: "test-action",
         actionVersion: "1.0.0",
-        isDevelopment: false,
-        namespace: "test-namespace",
         activationId: "test-activation",
         apiHost: "test-host",
         apiKey: "test-key",
-        region: "test-region",
         cloud: "test-cloud",
-        transactionId: "test-transaction",
         deadline: null,
+        isDevelopment: false,
+        namespace: "test-namespace",
         packageName: "test-package",
+        region: "test-region",
+        transactionId: "test-transaction",
       })),
+      isDevelopment: vi.fn(() => false),
 
       isTelemetryEnabled: vi.fn(() => true),
-      isDevelopment: vi.fn(() => false),
     }));
 
     instrumentation = await import("~/core/instrumentation");
@@ -222,14 +222,14 @@ describe("core/instrumentation", () => {
     });
 
     test("non-throwing functions should use isSuccessful predicate to determine success", () => {
-      const fn = vi.fn(() => ({ success: false, data: "test" }));
+      const fn = vi.fn(() => ({ data: "test", success: false }));
       const isSuccessful = vi.fn(
         (result: { success: boolean }) => result.success === true,
       );
 
       const instrumentedFn = instrumentation.instrument(fn, {
-        spanConfig: { spanName: "predicate-test" },
         isSuccessful,
+        spanConfig: { spanName: "predicate-test" },
       });
 
       instrumentedFn();
@@ -245,10 +245,10 @@ describe("core/instrumentation", () => {
       });
 
       const nonSuccessfulInstrumentedFn = instrumentation.instrument(fn, {
-        isSuccessful: () => false,
         hooks: {
           onResult,
         },
+        isSuccessful: () => false,
       });
 
       const result = instrumentedFn();
@@ -411,8 +411,8 @@ describe("core/instrumentation", () => {
 
       mockInitializeTelemetry = vi.fn(
         (_params: Record<string, unknown>, _isDevelopment: boolean) => ({
-          sdkConfig: {},
           diagnostics: { logLevel: "error" },
+          sdkConfig: {},
         }),
       );
     });
@@ -569,11 +569,11 @@ describe("core/instrumentation", () => {
       );
 
       instrumentedMain({
-        ENABLE_TELEMETRY: "true",
         __telemetryContext: {
           traceparent:
             "00-1234567890abcdef1234567890abcdef-1234567890abcdef-01",
         },
+        ENABLE_TELEMETRY: "true",
       });
 
       if (!capturedSpanContext) {
@@ -592,7 +592,7 @@ describe("core/instrumentation", () => {
         propagation: {
           getContextCarrier: (entrypointParams) => {
             capturedParams = entrypointParams;
-            return { carrier: {}, baseCtx: undefined };
+            return { baseCtx: undefined, carrier: {} };
           },
         },
       });
@@ -605,9 +605,9 @@ describe("core/instrumentation", () => {
 
     test("should use custom base context if provided", () => {
       const baseContext = {
+        deleteValue: vi.fn(),
         getValue: vi.fn(),
         setValue: vi.fn(),
-        deleteValue: vi.fn(),
       } satisfies Context;
 
       const spy = vi.spyOn(tracer, "startActiveSpan");
@@ -618,7 +618,7 @@ describe("core/instrumentation", () => {
         {
           initializeTelemetry: mockInitializeTelemetry,
           propagation: {
-            getContextCarrier: () => ({ carrier: {}, baseCtx: baseContext }),
+            getContextCarrier: () => ({ baseCtx: baseContext, carrier: {} }),
           },
         },
       );
@@ -765,8 +765,8 @@ describe("core/instrumentation", () => {
 
     test("should mark root span as error if the runtime action fails", () => {
       const error = {
-        statusCode: 500,
         message: "Runtime action failed",
+        statusCode: 500,
       };
 
       let spy: MockInstance | null = null;

--- a/tests/unit/core/logging.test.ts
+++ b/tests/unit/core/logging.test.ts
@@ -30,18 +30,18 @@ vi.mock("@opentelemetry/winston-transport", () => ({
 
 vi.mock("@opentelemetry/api", () => ({
   DiagLogLevel: {
-    NONE: 0,
-    ERROR: 1,
-    WARN: 2,
-    INFO: 3,
-    DEBUG: 4,
-    VERBOSE: 5,
     ALL: 6,
+    DEBUG: 4,
+    ERROR: 1,
+    INFO: 3,
+    NONE: 0,
+    VERBOSE: 5,
+    WARN: 2,
   },
   diag: {
-    setLogger: vi.fn(),
-    info: vi.fn(),
     error: vi.fn(),
+    info: vi.fn(),
+    setLogger: vi.fn(),
   },
 }));
 
@@ -55,16 +55,16 @@ vi.mock("~/core/sdk", () => ({
 
 describe("core/logging", () => {
   const mockLogger = {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
     logger: {
       logger: {
         add: vi.fn(),
       },
     },
-    info: vi.fn(),
-    debug: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
     verbose: vi.fn(),
+    warn: vi.fn(),
   };
 
   beforeEach(() => {
@@ -89,8 +89,8 @@ describe("core/logging", () => {
 
       expect(sdkModule.ensureSdkInitialized).toHaveBeenCalled();
       expect(AioLogger).toHaveBeenCalledWith("test-logger", {
-        provider: "winston",
         level: "info",
+        provider: "winston",
       });
     });
 
@@ -133,8 +133,8 @@ describe("core/logging", () => {
     test("should handle undefined log level", () => {
       getLogger("test-logger", { level: undefined });
       expect(AioLogger).toHaveBeenCalledWith("test-logger", {
-        provider: "winston",
         level: "info",
+        provider: "winston",
       });
     });
   });
@@ -142,8 +142,8 @@ describe("core/logging", () => {
   describe("setOtelDiagLogger", () => {
     test("should set diagnostics logger with info level", () => {
       setOtelDiagLogger({
-        logLevel: "info",
         exportLogs: true,
+        logLevel: "info",
       });
 
       expect(AioLogger).toHaveBeenCalledWith("test-action/otel-diagnostics", {
@@ -163,9 +163,9 @@ describe("core/logging", () => {
 
     test("should use custom logger name", () => {
       setOtelDiagLogger({
-        logLevel: "debug",
-        loggerName: "custom-diag-logger",
         exportLogs: true,
+        loggerName: "custom-diag-logger",
+        logLevel: "debug",
       });
 
       expect(AioLogger).toHaveBeenCalledWith("custom-diag-logger", {
@@ -177,15 +177,15 @@ describe("core/logging", () => {
 
     test.each([
       // { input: "none" as const, aioLevel: undefined, diagLevel: "NONE" },
-      { input: "all" as const, aioLevel: "verbose", diagLevel: "ALL" },
-      { input: "error" as const, aioLevel: "error", diagLevel: "ERROR" },
-      { input: "warn" as const, aioLevel: "warn", diagLevel: "WARN" },
-      { input: "info" as const, aioLevel: "info", diagLevel: "INFO" },
-      { input: "debug" as const, aioLevel: "debug", diagLevel: "DEBUG" },
+      { aioLevel: "verbose", diagLevel: "ALL", input: "all" as const },
+      { aioLevel: "error", diagLevel: "ERROR", input: "error" as const },
+      { aioLevel: "warn", diagLevel: "WARN", input: "warn" as const },
+      { aioLevel: "info", diagLevel: "INFO", input: "info" as const },
+      { aioLevel: "debug", diagLevel: "DEBUG", input: "debug" as const },
       {
-        input: "verbose" as const,
         aioLevel: "verbose",
         diagLevel: "VERBOSE",
+        input: "verbose" as const,
       },
     ] as const)("should map log level '$input' to equivalent AIO logger level '$aioLevel' and OpenTelemetry diagnostics logger level '$diagLevel'   correctly", ({
       input,
@@ -193,8 +193,8 @@ describe("core/logging", () => {
       diagLevel,
     }) => {
       setOtelDiagLogger({
-        logLevel: input,
         exportLogs: true,
+        logLevel: input,
       });
 
       expect(AioLogger).toHaveBeenCalledWith(
@@ -213,8 +213,8 @@ describe("core/logging", () => {
       "error",
     ] as const)("should export diagnostic logs for level '%s'", (level) => {
       setOtelDiagLogger({
-        logLevel: level,
         exportLogs: true,
+        logLevel: level,
       });
 
       expect(mockLogger.logger.logger.add).toHaveBeenCalled();
@@ -224,8 +224,8 @@ describe("core/logging", () => {
     test("should export logs only for info, warn, and error levels", () => {
       // Test info level - should export
       setOtelDiagLogger({
-        logLevel: "info",
         exportLogs: true,
+        logLevel: "info",
       });
 
       expect(mockLogger.logger.logger.add).toHaveBeenCalled();
@@ -237,8 +237,8 @@ describe("core/logging", () => {
 
       // Test debug level - should not export
       setOtelDiagLogger({
-        logLevel: "debug",
         exportLogs: true,
+        logLevel: "debug",
       });
 
       expect(mockLogger.logger.logger.add).toHaveBeenCalled();
@@ -249,8 +249,8 @@ describe("core/logging", () => {
 
     test("should not add transport when exportLogs is false", () => {
       setOtelDiagLogger({
-        logLevel: "info",
         exportLogs: false,
+        logLevel: "info",
       });
 
       expect(mockLogger.logger.logger.add).not.toHaveBeenCalled();
@@ -262,8 +262,8 @@ describe("core/logging", () => {
       });
 
       setOtelDiagLogger({
-        logLevel: "info",
         exportLogs: true,
+        logLevel: "info",
       });
 
       expect(diag.error).toHaveBeenCalledWith(
@@ -274,8 +274,8 @@ describe("core/logging", () => {
 
     test("should not call ensureSdkInitialized for diagnostics logger", () => {
       setOtelDiagLogger({
-        logLevel: "info",
         exportLogs: true,
+        logLevel: "info",
       });
 
       expect(sdkModule.ensureSdkInitialized).not.toHaveBeenCalled();

--- a/tests/unit/core/metrics.test.ts
+++ b/tests/unit/core/metrics.test.ts
@@ -114,8 +114,8 @@ describe("core/metrics", () => {
 
       expect(() => proxy.requestCount).toThrow(
         expect.objectContaining({
-          message: expect.stringContaining(error.message),
           cause: error,
+          message: expect.stringContaining(error.message),
         }),
       );
     });
@@ -132,8 +132,8 @@ describe("core/metrics", () => {
 
       expect(() => proxy.requestCount).toThrow(
         expect.objectContaining({
-          message: expect.stringContaining(error.message),
           cause: error,
+          message: expect.stringContaining(error.message),
         }),
       );
     });
@@ -160,8 +160,8 @@ describe("core/metrics", () => {
       mockMeter.createCounter.mockReturnValueOnce(mockCounter);
 
       const createMetricsFn = vi.fn((meter: Meter) => ({
-        requestCount: meter.createCounter("request.count"),
         errorCount: meter.createCounter("error.count"),
+        requestCount: meter.createCounter("request.count"),
       }));
 
       const proxy = coreMetrics.defineMetrics(createMetricsFn);

--- a/tests/unit/core/sdk.test.ts
+++ b/tests/unit/core/sdk.test.ts
@@ -50,8 +50,8 @@ describe("core/sdk", () => {
   const setOtelDiagLogger = vi.fn();
 
   const mockNodeSdk = {
-    start: startSdk,
     shutdown: shutdownSdk,
+    start: startSdk,
   };
 
   const NodeSdk = vi.fn().mockImplementation(function (this: never) {
@@ -67,9 +67,9 @@ describe("core/sdk", () => {
 
     vi.doMock("@opentelemetry/api", () => ({
       diag: {
-        warn: diagWarn,
-        info: diagInfo,
         error: diagError,
+        info: diagInfo,
+        warn: diagWarn,
       },
     }));
 
@@ -98,9 +98,9 @@ describe("core/sdk", () => {
   describe("initializeDiagnostics", () => {
     test("should initialize diagnostics when SDK is not initialized", () => {
       const diagnosticsConfig = {
-        logLevel: "debug",
-        loggerName: "test-logger",
         exportLogs: true,
+        loggerName: "test-logger",
+        logLevel: "debug",
       } as const;
 
       coreSdk.initializeDiagnostics(diagnosticsConfig);

--- a/tests/unit/core/telemetry-api.test.ts
+++ b/tests/unit/core/telemetry-api.test.ts
@@ -64,7 +64,7 @@ describe("core/telemetry-api", () => {
     });
 
     test("should return the global telemetry API when initialized", () => {
-      const api = { tracer: mockTracer, meter: mockMeter };
+      const api = { meter: mockMeter, tracer: mockTracer };
       vi.stubGlobal("__OTEL_TELEMETRY_API__", api);
 
       const result = coreTelemetryApi.getGlobalTelemetryApi();
@@ -100,8 +100,8 @@ describe("core/telemetry-api", () => {
       const customMeter = { createCounter: vi.fn() };
 
       coreTelemetryApi.initializeGlobalTelemetryApi({
-        tracer: customTracer as unknown as Tracer,
         meter: customMeter as unknown as Meter,
+        tracer: customTracer as unknown as Tracer,
       });
 
       const api = globalThis.__OTEL_TELEMETRY_API__;
@@ -169,13 +169,13 @@ describe("core/telemetry-api", () => {
       const secondMeter = { createCounter: vi.fn() };
 
       const firstApi = {
-        tracer: firstTracer as unknown as Tracer,
         meter: firstMeter as unknown as Meter,
+        tracer: firstTracer as unknown as Tracer,
       };
 
       const secondApi = {
-        tracer: secondTracer as unknown as Tracer,
         meter: secondMeter as unknown as Meter,
+        tracer: secondTracer as unknown as Tracer,
       };
 
       coreTelemetryApi.initializeGlobalTelemetryApi(firstApi);

--- a/tests/unit/helpers/runtime.test.ts
+++ b/tests/unit/helpers/runtime.test.ts
@@ -95,20 +95,20 @@ describe("helpers/runtime", () => {
 
       const metadata = runtimeHelpers.getRuntimeActionMetadata();
       expect(metadata).toEqual({
+        actionName: "test-prod-action-name",
+        actionVersion: "1.0.0",
         activationId: "test-prod-activation-id",
-        namespace: "test-prod-namespace",
         apiHost: "test-prod-api-host",
         apiKey: "test-prod-api-key",
-        isDevelopment: false,
-
-        region: "test-prod-region",
         cloud: "test-prod-cloud",
-        transactionId: "test-prod-transaction-id",
-        actionVersion: "1.0.0",
         deadline: expect.any(Date),
+        isDevelopment: false,
+        namespace: "test-prod-namespace",
 
         packageName: "test-prod-package-name",
-        actionName: "test-prod-action-name",
+
+        region: "test-prod-region",
+        transactionId: "test-prod-transaction-id",
       });
     });
 
@@ -117,20 +117,20 @@ describe("helpers/runtime", () => {
 
       const metadata = runtimeHelpers.getRuntimeActionMetadata();
       expect(metadata).toEqual({
-        activationId: "test-dev-activation-id",
-        namespace: "test-dev-namespace",
-        apiHost: "test-dev-api-host",
-        apiKey: "test-dev-api-key",
-        isDevelopment: true,
-
-        region: "local",
-        cloud: "local",
-        transactionId: "unknown",
-        deadline: null,
-
-        packageName: "test-dev-package-name",
         actionName: "test-dev-action-name",
         actionVersion: "0.0.0 (development)",
+        activationId: "test-dev-activation-id",
+        apiHost: "test-dev-api-host",
+        apiKey: "test-dev-api-key",
+        cloud: "local",
+        deadline: null,
+        isDevelopment: true,
+        namespace: "test-dev-namespace",
+
+        packageName: "test-dev-package-name",
+
+        region: "local",
+        transactionId: "unknown",
       });
     });
 
@@ -139,20 +139,20 @@ describe("helpers/runtime", () => {
 
       const metadata = runtimeHelpers.getRuntimeActionMetadata();
       expect(metadata).toEqual({
-        activationId: "test-dev-activation-id",
-        namespace: "test-dev-namespace",
-        apiHost: "test-dev-api-host",
-        apiKey: "test-dev-api-key",
-        isDevelopment: true,
-
-        region: "local",
-        cloud: "local",
-        transactionId: "unknown",
-        deadline: null,
-
-        packageName: "unknown",
         actionName: "test-dev-action-name",
         actionVersion: "0.0.0 (development)",
+        activationId: "test-dev-activation-id",
+        apiHost: "test-dev-api-host",
+        apiKey: "test-dev-api-key",
+        cloud: "local",
+        deadline: null,
+        isDevelopment: true,
+        namespace: "test-dev-namespace",
+
+        packageName: "unknown",
+
+        region: "local",
+        transactionId: "unknown",
       });
     });
 
@@ -171,16 +171,16 @@ describe("helpers/runtime", () => {
         runtimeHelpers.inferTelemetryAttributesFromRuntimeMetadata();
 
       expect(attributes).toEqual({
-        "service.version": "1.0.0",
-        "service.name": "test-prod-namespace/test-prod-package-name",
-        environment: "production",
+        "action.activation_id": "test-prod-activation-id",
+        "action.deadline": expect.stringMatching(ISO_DATE_REGEX),
 
         "action.name": "test-prod-action-name",
-        "action.package_name": "test-prod-package-name",
         "action.namespace": "test-prod-namespace",
-        "action.activation_id": "test-prod-activation-id",
+        "action.package_name": "test-prod-package-name",
         "action.transaction_id": "test-prod-transaction-id",
-        "action.deadline": expect.stringMatching(ISO_DATE_REGEX),
+        environment: "production",
+        "service.name": "test-prod-namespace/test-prod-package-name",
+        "service.version": "1.0.0",
       });
     });
 
@@ -190,15 +190,15 @@ describe("helpers/runtime", () => {
         runtimeHelpers.inferTelemetryAttributesFromRuntimeMetadata();
 
       expect(attributes).toEqual({
-        "service.name":
-          "test-dev-namespace-local-development/test-dev-package-name",
-
-        environment: "development",
+        "action.activation_id": "test-dev-activation-id",
 
         "action.name": "test-dev-action-name",
-        "action.package_name": "test-dev-package-name",
         "action.namespace": "test-dev-namespace",
-        "action.activation_id": "test-dev-activation-id",
+        "action.package_name": "test-dev-package-name",
+
+        environment: "development",
+        "service.name":
+          "test-dev-namespace-local-development/test-dev-package-name",
       });
     });
 
@@ -208,13 +208,13 @@ describe("helpers/runtime", () => {
         runtimeHelpers.inferTelemetryAttributesFromRuntimeMetadata();
 
       expect(attributes).toEqual({
-        "service.name": "test-dev-namespace-local-development",
-
-        environment: "development",
+        "action.activation_id": "test-dev-activation-id",
 
         "action.name": "test-dev-action-name",
         "action.namespace": "test-dev-namespace",
-        "action.activation_id": "test-dev-activation-id",
+
+        environment: "development",
+        "service.name": "test-dev-namespace-local-development",
       });
     });
   });

--- a/tests/unit/integrations/commerce.test.ts
+++ b/tests/unit/integrations/commerce.test.ts
@@ -35,9 +35,9 @@ describe("integrations/commerce", () => {
   ) {
     let capturedSpanContext: SpanContext | null = null;
     const mockInitializeTelemetry = vi.fn(() => ({
+      meter,
       sdkConfig: {},
       tracer,
-      meter,
     }));
 
     const instrumentedMain = instrumentation.instrumentEntrypoint(
@@ -68,28 +68,28 @@ describe("integrations/commerce", () => {
     tracer = trace.getTracer("test-tracer");
     meter = metrics.getMeter("test-meter");
     vi.stubGlobal("__OTEL_TELEMETRY_API__", {
-      tracer,
       meter,
+      tracer,
     });
 
     vi.doMock("~/helpers/runtime", () => ({
       getRuntimeActionMetadata: vi.fn(() => ({
         actionName: "test-action",
         actionVersion: "1.0.0",
-        isDevelopment: false,
-        namespace: "test-namespace",
         activationId: "test-activation",
         apiHost: "test-host",
         apiKey: "test-key",
-        region: "test-region",
         cloud: "test-cloud",
-        transactionId: "test-transaction",
         deadline: null,
+        isDevelopment: false,
+        namespace: "test-namespace",
         packageName: "test-package",
+        region: "test-region",
+        transactionId: "test-transaction",
       })),
+      isDevelopment: vi.fn(() => false),
 
       isTelemetryEnabled: vi.fn(() => true),
-      isDevelopment: vi.fn(() => false),
     }));
 
     await import("~/helpers/runtime");
@@ -107,10 +107,10 @@ describe("integrations/commerce", () => {
     const spy = vi.spyOn(commerceIntegration, "patchInstrumentationConfig");
 
     const mockInitializeTelemetry = vi.fn(() => ({
-      sdkConfig: {},
       integrations: [commerceIntegration],
-      tracer,
       meter,
+      sdkConfig: {},
+      tracer,
     }));
 
     const instrumentedMain = instrumentation.instrumentEntrypoint(
@@ -118,9 +118,9 @@ describe("integrations/commerce", () => {
         return { statusCode: 200 };
       },
       {
+        initializeTelemetry: mockInitializeTelemetry,
         // Override the default integrations with an empty array
         integrations: [],
-        initializeTelemetry: mockInitializeTelemetry,
       },
     );
 
@@ -185,13 +185,13 @@ describe("integrations/commerce", () => {
         createInstrumentedEntrypointWithCapture(integration);
 
       const params = {
-        ENABLE_TELEMETRY: "true",
         data: {
           _metadata: {
             traceparent:
               "00-1234567890abcdef1234567890abcdef-1234567890abcdef-01",
           },
         },
+        ENABLE_TELEMETRY: "true",
       };
 
       execute(params);
@@ -213,13 +213,13 @@ describe("integrations/commerce", () => {
       const { execute } = createInstrumentedEntrypointWithCapture(integration);
 
       const params = {
-        ENABLE_TELEMETRY: "true",
         data: {
           _metadata: {
             traceparent:
               "00-1234567890abcdef1234567890abcdef-1234567890abcdef-01",
           },
         },
+        ENABLE_TELEMETRY: "true",
       };
 
       execute(params);
@@ -270,11 +270,11 @@ describe("integrations/commerce", () => {
         createInstrumentedEntrypointWithCapture(integration);
 
       const params = {
-        ENABLE_TELEMETRY: "true",
         __ow_headers: {
           traceparent:
             "00-1234567890abcdef1234567890abcdef-1234567890abcdef-01",
         },
+        ENABLE_TELEMETRY: "true",
       };
 
       execute(params);
@@ -296,12 +296,12 @@ describe("integrations/commerce", () => {
         createInstrumentedEntrypointWithCapture(integration);
 
       const params = {
-        ENABLE_TELEMETRY: "true",
         __ow_headers: {
           // Non-sampled trace (last byte is 00 instead of 01)
           traceparent:
             "00-1234567890abcdef1234567890abcdef-1234567890abcdef-00",
         },
+        ENABLE_TELEMETRY: "true",
       };
 
       execute(params);
@@ -323,12 +323,12 @@ describe("integrations/commerce", () => {
         createInstrumentedEntrypointWithCapture(integration);
 
       const params = {
-        ENABLE_TELEMETRY: "true",
         __ow_headers: {
           // Non-sampled trace (last byte is 00 instead of 01)
           traceparent:
             "00-1234567890abcdef1234567890abcdef-1234567890abcdef-00",
         },
+        ENABLE_TELEMETRY: "true",
       };
 
       execute(params);
@@ -350,12 +350,12 @@ describe("integrations/commerce", () => {
       const { execute } = createInstrumentedEntrypointWithCapture(integration);
 
       const params = {
-        ENABLE_TELEMETRY: "true",
         __ow_headers: {
           // Non-sampled trace
           traceparent:
             "00-1234567890abcdef1234567890abcdef-1234567890abcdef-00",
         },
+        ENABLE_TELEMETRY: "true",
       };
 
       execute(params);

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -30,11 +30,18 @@ const ADOBE_LICENSE_BANNER = `
 `.trimStart();
 
 export default defineConfig({
+  banner: {
+    dts: ADOBE_LICENSE_BANNER,
+    js: ADOBE_LICENSE_BANNER,
+  },
+  dts: true,
   entry: [
     "./source/index.ts",
     "./source/otel.ts",
     "./source/integrations/index.ts",
   ],
+
+  failOnWarn: "ci-only",
 
   format: {
     cjs: {
@@ -48,25 +55,18 @@ export default defineConfig({
       },
     },
   },
-
-  publint: true,
-  outputOptions: {
-    legalComments: "inline",
-    dir: OUT_DIR,
-
-    minifyInternalExports: true,
-  },
-
-  failOnWarn: "ci-only",
-  dts: true,
-  treeshake: true,
   minify: {
     compress: true,
   },
 
   nodeProtocol: "strip",
-  banner: {
-    js: ADOBE_LICENSE_BANNER,
-    dts: ADOBE_LICENSE_BANNER,
+  outputOptions: {
+    dir: OUT_DIR,
+    legalComments: "inline",
+
+    minifyInternalExports: true,
   },
+
+  publint: true,
+  treeshake: true,
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,31 +16,29 @@ import { coverageConfigDefaults, defineConfig } from "vitest/config";
 export default defineConfig({
   plugins: [tsconfigPaths()],
   test: {
-    globals: true,
-    environment: "node",
-
     coverage: {
       enabled: true,
-      provider: "v8",
-      reporter: ["html-spa", "html", "text"],
-
-      reportOnFailure: true,
       exclude: [
         ...coverageConfigDefaults.exclude,
         "source/{index,otel,types}.ts",
         "source/integrations/index.ts",
         "tsdown.config.ts",
       ],
+      provider: "v8",
+      reporter: ["html-spa", "html", "text"],
+
+      reportOnFailure: true,
 
       thresholds: {
-        statements: 100,
-        functions: 100,
-        lines: 100,
-
         // Reduced this from 100 because it complains about a couple of branches
         // not being covered when they actually are. Probably a bug with reporting.
         branches: 98,
+        functions: 100,
+        lines: 100,
+        statements: 100,
       },
     },
+    environment: "node",
+    globals: true,
   },
 });


### PR DESCRIPTION
## Description

Bumps ultracite from 7.7.0 to 7.9.3, along with @biomejs/biome (a peer requirement of the new ultracite config) from 2.4.15 to 2.5.2, and fixes the lint/format issues surfaced by the new rules.

## Related Issue

N/A

## Motivation and Context

ultracite 7.9.0 broke CI in the renovate lock file maintenance PR (#120) with new lint rules. That PR now pins ultracite below 7.9.0 to unblock; this PR does the bump properly on its own.

## How Has This Been Tested?

Ran typecheck, build, full test suite (100% coverage maintained), and biome checks locally, including verifying `npm ci` works under both the npm bundled with Node 22 and Node 24 (matching the CI matrix).

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the Adobe Open Source CLA.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.